### PR TITLE
Change CMake install location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -845,7 +845,7 @@ install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}Targets)
 install(
   EXPORT ${PROJECT_NAME}Targets 
   NAMESPACE ${PROJECT_NAME}:: 
-  DESTINATION ${TF_LIB_INSTALL_DIR}/cmake
+  DESTINATION ${TF_LIB_INSTALL_DIR}/cmake/${PROJECT_NAME}
 )
 
 # set up config
@@ -854,7 +854,7 @@ include(CMakePackageConfigHelpers)
 configure_package_config_file(
   ${PROJECT_NAME}Config.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
-  INSTALL_DESTINATION ${TF_LIB_INSTALL_DIR}/cmake
+  INSTALL_DESTINATION ${TF_LIB_INSTALL_DIR}/cmake/${PROJECT_NAME}
   PATH_VARS TF_INC_INSTALL_DIR
 )
 
@@ -866,6 +866,6 @@ write_basic_package_version_file(
 install(
   FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
         ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
-  DESTINATION ${TF_LIB_INSTALL_DIR}/cmake 
+  DESTINATION ${TF_LIB_INSTALL_DIR}/cmake/${PROJECT_NAME}
 )
 

--- a/TaskflowConfig.cmake.in
+++ b/TaskflowConfig.cmake.in
@@ -2,6 +2,7 @@
 
 set_and_check(@PROJECT_NAME@_INCLUDE_DIR "@PACKAGE_TF_INC_INSTALL_DIR@")
 
+include(CMakeFindDependencyMacro)
 find_dependency(Threads)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")


### PR DESCRIPTION
Changes the install location of the package configuration file from `${TF_LIB_INSTALL_DIR}/cmake` to `${TF_LIB_INSTALL_DIR}/cmake/${PROJECT_NAME}`. This matches the typical install location according to [this](https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html) where it states


> The find_package() command may be used to search for the package configuration file. This command constructs a set of installation prefixes and searches under each prefix in several locations. Given the name Foo, it looks for a file called FooConfig.cmake or foo-config.cmake. The full set of locations is specified in the find_package() command documentation. One place it looks is:
> 
> `<prefix>/lib/cmake/Foo*/`

The current install location creates a problem since it is not a search location as shown below from the [documentation for find_package](https://cmake.org/cmake/help/latest/command/find_package.html#search-procedure)
```
<prefix>/                                                       (W)
<prefix>/(cmake|CMake)/                                         (W)
<prefix>/<name>*/                                               (W)
<prefix>/<name>*/(cmake|CMake)/                                 (W)
<prefix>/(lib/<arch>|lib*|share)/cmake/<name>*/                 (U)
<prefix>/(lib/<arch>|lib*|share)/<name>*/                       (U)
<prefix>/(lib/<arch>|lib*|share)/<name>*/(cmake|CMake)/         (U)
<prefix>/<name>*/(lib/<arch>|lib*|share)/cmake/<name>*/         (W/U)
<prefix>/<name>*/(lib/<arch>|lib*|share)/<name>*/               (W/U)
<prefix>/<name>*/(lib/<arch>|lib*|share)/<name>*/(cmake|CMake)/ (W/U)
```

This also fixes a small problem with a missing include when finding this package.