### PR TITLE
Support custom domain

### DIFF
--- a/taskflow/core/executor.hpp
+++ b/taskflow/core/executor.hpp
@@ -59,7 +59,7 @@ class Executor {
     /**
     @brief constructs the executor with N worker threads
     */
-    explicit Executor(size_t N = std::thread::hardware_concurrency());
+    explicit Executor(size_t N = std::thread::hardware_concurrency(), size_t M = 1);
 #endif
     
     /**
@@ -330,13 +330,13 @@ inline Executor::Executor(size_t N, size_t M) :
 
 #else
 // Constructor
-inline Executor::Executor(size_t N) : 
+inline Executor::Executor(size_t N, size_t M) :
   _VICTIM_BEG {0},
   _VICTIM_END {N - 1},
   _MAX_STEALS {(N + 1) << 1},
   _MAX_YIELDS {100},
-  _workers    {N},
-  _notifier   {Notifier(N)} {
+  _workers    {N+M},
+  _notifier   {Notifier(N), Notifier(M)} {
   
   if(N == 0) {
     TF_THROW("no cpu workers to execute taskflows");
@@ -348,6 +348,9 @@ inline Executor::Executor(size_t N) :
   }
 
   _spawn(N, HOST);
+  if (M > 0) {
+    _spawn(M, HOST);
+  }
 
   // instantite the default observer if requested
   _instantiate_tfprof();

--- a/taskflow/core/graph.hpp
+++ b/taskflow/core/graph.hpp
@@ -23,6 +23,7 @@ namespace tf {
 
 enum Domain : int {
   HOST = 0,
+  GPU,
 #ifdef TF_ENABLE_CUDA
   CUDA,
 #endif
@@ -177,6 +178,9 @@ class Node {
     const std::string& name() const;
 
     Domain domain() const;
+    void set_domain(Domain d) {
+      _domain = d;
+    }
 
   private:
 
@@ -192,6 +196,7 @@ class Node {
     Node* _parent {nullptr};
 
     int _state {0};
+    Domain _domain {Domain::HOST};
 
     std::atomic<size_t> _join_counter {0};
     
@@ -331,6 +336,9 @@ inline const std::string& Node::name() const {
 
 // Function: domain
 inline Domain Node::domain() const {
+  if (_domain != Domain::HOST) {
+    return _domain;
+  }
 
   Domain domain;
 

--- a/taskflow/core/task.hpp
+++ b/taskflow/core/task.hpp
@@ -307,6 +307,10 @@ class Task {
     */
     TaskType type() const;
 
+    void set_domain(Domain d) {
+      _node->set_domain(d);
+    }
+
   private:
     
     Task(Node*);


### PR DESCRIPTION
This is a simple way to address my desires in #160.  Maybe also starts to speak to #191.  Not sure it's exactly what you'd want to add to the api but wanted to share a possible way forward.  I think my ideal case would be to be able to separate this from executors and be able to have the domains (or some concurrency object) dynamically defined by client code.

By the way, I had lots of issues with trailing whitespace preparing this diff.  Would you be interested in a PR that cleans that up across the repo?