### PR TITLE
Added static_cast for double to size_t conversion

### DIFF
--- a/taskflow/algorithm/parallel_for.hpp
+++ b/taskflow/algorithm/parallel_for.hpp
@@ -255,7 +255,7 @@ Task FlowBuilder::parallel_for_guided(
           }
           // coarse-grained
           else {
-            size_t q = p2 * r;
+            size_t q = static_cast<size_t>(p2 * r);
             if(q < chunk_size) {
               q = chunk_size;
             }


### PR DESCRIPTION
I forgot one as I was only specializing the default schedule.