### PR TITLE
Prevent min max macros expansion when windows.h header is included in project alongside taskflow

### DIFF
--- a/taskflow/utility/object_pool.hpp
+++ b/taskflow/utility/object_pool.hpp
@@ -65,7 +65,7 @@ template <typename T, size_t S = 65536>
 class ObjectPool { 
   
   // the data column must be sufficient to hold the pointer in freelist  
-  constexpr static size_t X = std::max(sizeof(T*), sizeof(T));
+  constexpr static size_t X = (std::max)(sizeof(T*), sizeof(T));
   //constexpr static size_t X = sizeof(long double) + std::max(sizeof(T*), sizeof(T));
   //constexpr static size_t M = (S - offsetof(Block, data)) / X;
   constexpr static size_t M = S / X;

--- a/taskflow/utility/passive_vector.hpp
+++ b/taskflow/utility/passive_vector.hpp
@@ -173,7 +173,7 @@ class PassiveVector {
 
     size_type size() const     { return _num; }
     size_type capacity() const { return _cap; }
-    size_type max_size() const { return std::numeric_limits<size_type>::max(); }
+    size_type max_size() const { return (std::numeric_limits<size_type>::max)(); }
 
     bool operator == (const PassiveVector& rhs) const {
       if(_num != rhs._num) {

--- a/taskflow/utility/uuid.hpp
+++ b/taskflow/utility/uuid.hpp
@@ -75,8 +75,8 @@ inline UUID::UUID() {
   static thread_local std::mt19937 engine {rd()};
 
   std::uniform_int_distribution<unsigned long> distribution(
-    std::numeric_limits<unsigned long>::min(),
-    std::numeric_limits<unsigned long>::max()
+    (std::numeric_limits<unsigned long>::min)(),
+    (std::numeric_limits<unsigned long>::max)()
   );
   
   int i = 0;


### PR DESCRIPTION
Fix for the reported issue #242 