### PR TITLE
Add support for the Intel C++ compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,11 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     message(STATUS "CMAKE_CXX_COMPILER_VERSION: ${CMAKE_CXX_COMPILER_VERSION}")
     message(FATAL_ERROR "\nTaskflow requires MSVC++ at least v14.14") 
   endif()
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.0.1")
+    message(STATUS "CMAKE_CXX_COMPILER_VERSION: ${CMAKE_CXX_COMPILER_VERSION}")
+    message(FATAL_ERROR "\nTaskflow requires icpc at least v19.0.1")
+  endif()
 else()
   message(FATAL_ERROR "\n\
 Taskflow currently supports the following compilers:\n\
@@ -60,6 +65,7 @@ Taskflow currently supports the following compilers:\n\
   - clang++ v6.0 or above\n\
   - MSVC++ v19.14 or above\n\
   - AppleClang v8 or above\n\
+  - Intel v19.0.1 or above\n\
 ")
 endif()
 

--- a/README.md
+++ b/README.md
@@ -583,6 +583,7 @@ To use the latest [Taskflow](https://github.com/taskflow/taskflow/archive/master
 + Clang C++ Compiler at least v6.0 with -std=c++17
 + Microsoft Visual Studio at least v15.7 (MSVC++ 19.14); see [vcpkg guide](https://github.com/taskflow/taskflow/issues/143)
 + AppleClang Xode Version at least v8
++ Intel C++ Compiler at least v19.0.1
 + Nvidia CUDA Toolkit and Compiler ([nvcc][nvcc]) at least v11.0 with -std=c++17
 
 Taskflow works on Linux, Windows, and Mac OS X. See the [C++ compiler support](https://en.cppreference.com/w/cpp/compiler_support) status.

--- a/taskflow/core/task.hpp
+++ b/taskflow/core/task.hpp
@@ -340,7 +340,7 @@ inline void Task::reset() {
 
 // Procedure: reset_work
 inline void Task::reset_work() {
-  _node->_handle = std::monostate{};
+  _node->_handle.emplace<std::monostate>()
 }
 
 // Function: name

--- a/taskflow/core/task.hpp
+++ b/taskflow/core/task.hpp
@@ -340,7 +340,7 @@ inline void Task::reset() {
 
 // Procedure: reset_work
 inline void Task::reset_work() {
-  _node->_handle.emplace<std::monostate>()
+  _node->_handle.emplace<std::monostate>();
 }
 
 // Function: name


### PR DESCRIPTION
This pull request is in response to issue #248. Versions of the intel C++ compiler icpc above v19.0.1 are known to support the C++17 core language features (see here https://en.cppreference.com/w/cpp/compiler_support). I have tested this pull request with versions v19.0.3.199 (2019-02-06)  and v19.1.3.304 (2020-09-25) of icpc.