### PR TITLE
Cancelling a taskflow

### DIFF
--- a/taskflow/core/executor.hpp
+++ b/taskflow/core/executor.hpp
@@ -354,7 +354,7 @@ auto Executor::async(F&& f, ArgsT&&... args) {
   );
 
   _schedule(node);
-
+  fu.set_async_node(node);
   return fu;
 }
 
@@ -1242,7 +1242,7 @@ auto Subflow::async(F&& f, ArgsT&&... args) {
   node->_parent = _parent;
 
   _executor._schedule(node);
-
+  fu.set_async_node(node);
   return fu;
 }
 

--- a/taskflow/core/executor.hpp
+++ b/taskflow/core/executor.hpp
@@ -1051,13 +1051,11 @@ inline void Executor::_tear_down_topology(Topology* tpg) {
   //assert(&tpg == &(f._topologies.front()));
 
   // case 1: we still need to run the topology again
-  if(! tpg->_pred() ) {
+  if(! tpg->_pred() &&  !tpg->is_cancel) {
     //tpg->_recover_num_sinks();
-    if (!tpg->is_cancel){
       assert(tpg->_join_counter == 0);
       tpg->_join_counter = tpg->_sources.size();
        _schedule(tpg->_sources); 
-    }
   }
   // case 2: the final run of this topology
   else {

--- a/taskflow/core/graph.hpp
+++ b/taskflow/core/graph.hpp
@@ -175,7 +175,7 @@ class Node {
     size_t num_dependents() const;
     size_t num_strong_dependents() const;
     size_t num_weak_dependents() const;
-    
+    std::atomic<bool> async_cancelled {false};
     const std::string& name() const;
 
   private:

--- a/taskflow/core/taskflow.hpp
+++ b/taskflow/core/taskflow.hpp
@@ -338,5 +338,85 @@ inline void Taskflow::_dump(
   }
 }
 
+
+template <typename T>
+class Future : public std::future<T> {
+  friend class Node;
+  friend class Topology;
+  public:
+    //future object to store futre object returned by executor.run_until
+    std::future<T> future_obj;
+
+    //function for running wait_until method of future object
+    template <class Clock, class Duration>
+    auto wait_until (const std::chrono::time_point<Clock,Duration>& abs_time) const {
+      return future_obj.wait_until(abs_time);
+    }
+
+    //function for running wait_for method of future object
+    template <class Rep, class Period>
+    auto wait_for (const std::chrono::duration<Rep,Period>& rel_time) const{
+      return future_obj.wait_for( rel_time);
+    }
+    
+    //function for running wait method of future object
+    void wait() const{
+      future_obj.wait();
+      return;
+    }
+
+    //function for running valid method of future object
+    bool valid() const noexcept{
+      return future_obj.valid();
+    }
+
+    //function for running get method of future object
+    //template<typename T>
+    //template <class _Res>
+    T get() {
+      //future_obj.wait();
+      return future_obj.get();
+    }
+
+    //function for running share method of future object
+    auto share(){
+      return future_obj.share();
+    }
+
+    //operator equivalent to "=" operator of future object
+    auto operator=(std::future<T>&& rhs) noexcept{
+      future_obj=rhs;
+    }
+
+    //method for setting is_cancel variable of the topology to true
+    void cancel(){
+      _topology->is_cancel=true;
+      return;
+    }
+
+    //method for setting the topology for this class
+    void set_tpg(Topology* tpg){
+      _topology=tpg;
+      return;
+    }
+
+    //method for setting async task node for this class
+    void set_async_node(Node* node){
+      _node=node;
+      return;
+    }
+
+    //method for setting async_cancelled of an async node to true.
+    void cancel_async(){
+      _node->async_cancelled=true;
+      return;
+    }
+
+  private:
+    Topology* _topology {nullptr};
+    Node* _node {nullptr};
+
+};
+
 }  // end of namespace tf. ---------------------------------------------------
 

--- a/taskflow/core/taskflow.hpp
+++ b/taskflow/core/taskflow.hpp
@@ -340,53 +340,15 @@ inline void Taskflow::_dump(
 
 
 template <typename T>
-class Future : public std::future<T> {
+class Future: public std::future<T>  {
   friend class Node;
   friend class Topology;
+  friend class Executor;
   public:
-    //future object to store futre object returned by executor.run_until
-    std::future<T> future_obj;
-
-    //function for running wait_until method of future object
-    template <class Clock, class Duration>
-    auto wait_until (const std::chrono::time_point<Clock,Duration>& abs_time) const {
-      return future_obj.wait_until(abs_time);
-    }
-
-    //function for running wait_for method of future object
-    template <class Rep, class Period>
-    auto wait_for (const std::chrono::duration<Rep,Period>& rel_time) const{
-      return future_obj.wait_for( rel_time);
-    }
+    Future():std::future<T> {}{}
     
-    //function for running wait method of future object
-    void wait() const{
-      future_obj.wait();
-      return;
-    }
-
-    //function for running valid method of future object
-    bool valid() const noexcept{
-      return future_obj.valid();
-    }
-
-    //function for running get method of future object
-    //template<typename T>
-    //template <class _Res>
-    T get() {
-      //future_obj.wait();
-      return future_obj.get();
-    }
-
-    //function for running share method of future object
-    auto share(){
-      return future_obj.share();
-    }
-
-    //operator equivalent to "=" operator of future object
-    auto operator=(std::future<T>&& rhs) noexcept{
-      future_obj=rhs;
-    }
+    Future(std::future<T> f): std::future<T> {std::move(f)} {}
+    
 
     //method for setting is_cancel variable of the topology to true
     void cancel(){
@@ -394,19 +356,6 @@ class Future : public std::future<T> {
       return;
     }
 
-    //method for setting the topology for this class
-    void set_tpg(Topology* tpg){
-      _topology=tpg;
-      return;
-    }
-
-    //method for setting async task node for this class
-    void set_async_node(Node* node){
-      _node=node;
-      return;
-    }
-
-    //method for setting async_cancelled of an async node to true.
     void cancel_async(){
       _node->async_cancelled=true;
       return;
@@ -415,6 +364,17 @@ class Future : public std::future<T> {
   private:
     Topology* _topology {nullptr};
     Node* _node {nullptr};
+
+
+    void set_tpg(Topology* tpg){
+      _topology=tpg;
+      return;
+    }
+
+    void set_async_node(Node* node){
+      _node=node;
+      return;
+    }
 
 };
 

--- a/taskflow/core/taskflow.hpp
+++ b/taskflow/core/taskflow.hpp
@@ -344,6 +344,7 @@ class Future: public std::future<T>  {
   friend class Node;
   friend class Topology;
   friend class Executor;
+  friend class Subflow;
   public:
     Future():std::future<T> {}{}
     

--- a/taskflow/core/topology.hpp
+++ b/taskflow/core/topology.hpp
@@ -17,7 +17,6 @@ class Topology {
     template <typename P, typename C>
     Topology(Taskflow&, P&&, C&&);
     std::atomic<bool> is_cancel {false};
-    std::atomic<bool> is_torn {false};
   private:
 
     Taskflow& _taskflow;

--- a/taskflow/core/topology.hpp
+++ b/taskflow/core/topology.hpp
@@ -16,7 +16,8 @@ class Topology {
 
     template <typename P, typename C>
     Topology(Taskflow&, P&&, C&&);
-    
+    std::atomic<bool> is_cancel {false};
+    std::atomic<bool> is_torn {false};
   private:
 
     Taskflow& _taskflow;

--- a/taskflow/utility/os.hpp
+++ b/taskflow/utility/os.hpp
@@ -21,6 +21,11 @@
 #define TF_OS_WINDOWS 1
 #endif
 
+#ifdef __CYGWIN__
+#undef TF_OS_WINDOWS
+#define TF_OS_WINDOWS 1
+#endif
+
 #if (defined __APPLE__ && defined __MACH__)
 #undef TF_OS_DARWIN
 #define TF_OS_DARWIN 1

--- a/unittests/basics.cpp
+++ b/unittests/basics.cpp
@@ -515,7 +515,7 @@ void sequential_runs(unsigned W) {
     B.precede(D); 
     C.precede(D);
 
-    std::list<std::future<void>> fu_list;
+    std::list<tf::Future<void>> fu_list;
     for(size_t i=0; i<500; i++) {
       if(i == 499) {
         executor.run(f).get();   // Synchronize the first 500 runs
@@ -2765,7 +2765,7 @@ void async(unsigned W) {
 
   tf::Executor executor(W);
 
-  std::vector<std::future<int>> fus;
+  std::vector<tf::Future<int>> fus;
 
   std::atomic<int> counter(0);
   
@@ -2818,7 +2818,7 @@ void nested_async(unsigned W) {
 
   tf::Executor executor(W);
 
-  std::vector<std::future<int>> fus;
+  std::vector<tf::Future<int>> fus;
 
   std::atomic<int> counter(0);
   


### PR DESCRIPTION
Sir,
Ojas Mithbavkar here. I had discussed with you a method involving a new function called _tear_cancelled_topology. You had suggested checking for the destruction of topology before completion of all references. It appears that such a case was happening in case of dynamic tasks. Hence I have devised a new method based on the join_counter.

In the normal run, the join_counter of the tpg keeps track of whether the node is last or not before tearing down the tpg. For cancelling, once the is_cancel flag is set to True, we prevent the execution of the function given to the node. 
```
if (!node->_topology->is_cancel){
    std::get<Node::StaticTask>(node->_handle).work();
  }
```


Next, we prevent any scheduling of its successors. 
```
if(--(node->_successors[i]->_join_counter) == 0) {
        if (!node->_topology->is_cancel){
          c.fetch_add(1);
          _schedule(node->_successors[i]);
        }
      }
```
If cancelled, the node is treated as a leaf node. The join_counter of the topology won't be incremented by the line `c.fetch_add(1);`  The counter would be decremented by `if (node->_topology->_join_counter.fetch_sub(1) == 1)` as always.  Thus, cancelling a tpg converts the existing nodes to leaf nodes, and the join_counter ensures that the tpg is torn down only once.
Also, to ensure that a false predicate does not reschedule a cancelled tpg, we add a check around that too.
```
if(! tpg->_pred() && !tpg->is_cancel  ) {
      assert(tpg->_join_counter == 0);
      tpg->_join_counter = tpg->_sources.size();
       _schedule(tpg->_sources); 
  }
```
The change in return type of exec.run from std::future to tf::Future remains.
Currently, this method passed all non-CUDA unit tests.

