### PR TITLE
fix template argument

### DIFF
--- a/taskflow/utility/serializer.hpp
+++ b/taskflow/utility/serializer.hpp
@@ -657,7 +657,7 @@ constexpr auto is_default_deserializable_v =
   is_std_array_v<T>;
 
 // Class: Deserializer
-template <typename Device = std::ostream, typename SizeType = std::streamsize>
+template <typename Device = std::istream, typename SizeType = std::streamsize>
 class Deserializer {
 
   public:


### PR DESCRIPTION
As we need to call `_device.read()`, the default template argument `Device` should be type of `std::istream`, I guess it was a copy-paste error.