### PR TITLE
Fix for FlowBuilder::sort due to by ref lambda capture of comparator function (issue #337)

### DIFF
--- a/taskflow/core/algorithm/sort.hpp
+++ b/taskflow/core/algorithm/sort.hpp
@@ -17,12 +17,12 @@ constexpr size_t parallel_sort_cutoff() {
     return 128;
   }
   else {
-    if(object_size < 16) return 4096;
-    else if(object_size < 32) return 2048;
-    else if(object_size < 64) return 1024;
-    else if(object_size < 128) return 768;
-    else if(object_size < 256) return 512;
-    else if(object_size < 512) return 256;
+    if constexpr(object_size < 16) return 4096;
+    else if constexpr(object_size < 32) return 2048;
+    else if constexpr(object_size < 64) return 1024;
+    else if constexpr(object_size < 128) return 768;
+    else if constexpr(object_size < 256) return 512;
+    else if constexpr(object_size < 512) return 256;
     else return 128;
   }
 }

--- a/taskflow/core/algorithm/sort.hpp
+++ b/taskflow/core/algorithm/sort.hpp
@@ -343,7 +343,7 @@ void parallel_pdqsort(
     // Sort the left partition first using recursion and 
     // do tail recursion elimination for the right-hand partition.
     sf.silent_async(
-      [&sf, begin, pivot_pos, &comp, bad_allowed, leftmost] () mutable {
+      [&sf, begin, pivot_pos, comp, bad_allowed, leftmost] () mutable {
         parallel_pdqsort(sf, begin, pivot_pos, comp, bad_allowed, leftmost);
       }
     );


### PR DESCRIPTION
parallel_pdqsort's recursive async lambda call to parallel_pdqsort was capturing a reference to Compare on caller function stack which isn't guaranteed to remain valid due to nature of Subflow::silent_async call; made it capture by value instead

https://github.com/taskflow/taskflow/issues/337