### PR TITLE
Make CMake installation relocatable

### DIFF
--- a/TaskflowConfig.cmake.in
+++ b/TaskflowConfig.cmake.in
@@ -1,13 +1,12 @@
 @PACKAGE_INIT@
 
-set_and_check(@PROJECT_NAME@_INCLUDE_DIR "@CMAKE_INSTALL_FULL_INCLUDEDIR@")
-
 include(CMakeFindDependencyMacro)
 find_dependency(Threads)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
 
 get_filename_component(@PROJECT_NAME@_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+get_target_property(@PROJECT_NAME@_INCLUDE_DIR @PROJECT_NAME@::@PROJECT_NAME@ INTERFACE_INCLUDE_DIRECTORIES)
 
 message(STATUS "@PROJECT_NAME@ found. Headers: ${@PROJECT_NAME@_INCLUDE_DIR}")
 


### PR DESCRIPTION
Currently we have the problem that if Taskflow is installed into a directory and then later on this installation is moved into another directory, the cmake find_package routine doesn't succeed. This is a [problem for the hunter package manager](https://github.com/cpp-pm/hunter/pull/470#issuecomment-923731949) and I think also other package managers may have this problem.

The Root cause of this is line 3 in TaskflowConfig.cmake.in where the include directory path gets hardcoded. When the installation is moved to another directory later on, this hardcoded path persists and causes an exception when `set_and_check` is called on line 3.

My proposed change fixes this problem by retrieving the include path from the cmake target `Taskflow::Taskflow`. In this way we can reuse the rather sophisticated logic that cmake generates to determine the include path in `TaskflowTargets.cmake` (which is generated by cmake)