### PR TITLE
Inrease macOS compatibility

### DIFF
--- a/taskflow/core/executor.hpp
+++ b/taskflow/core/executor.hpp
@@ -918,7 +918,7 @@ inline void Executor::_tear_down_invoke(Node* node, bool cancel) {
     // async task needs to carry out the promise
     case Node::ASYNC:
       if(cancel) {
-        std::get<Node::Async>(node->_handle).work(true);
+          std::get_if<Node::Async>(&(node->_handle))->work(true);
       }
       _tear_down_async(node);
     break;
@@ -959,9 +959,9 @@ inline void Executor::_observer_epilogue(Worker& worker, Node* node) {
 
 // Procedure: _invoke_static_task
 inline void Executor::_invoke_static_task(Worker& worker, Node* node) {
-  _observer_prologue(worker, node);
-  std::get<Node::Static>(node->_handle).work();
-  _observer_epilogue(worker, node);
+    _observer_prologue(worker, node);
+    std::get_if<Node::Static>(&(node->_handle))->work();
+    _observer_epilogue(worker, node);
 }
 
 // Procedure: _invoke_dynamic_task
@@ -969,7 +969,7 @@ inline void Executor::_invoke_dynamic_task(Worker& w, Node* node) {
 
   _observer_prologue(w, node);
 
-  auto& handle = std::get<Node::Dynamic>(node->_handle);
+  auto& handle = *(std::get_if<Node::Dynamic>(&(node->_handle)));
 
   handle.subgraph.clear();
 
@@ -1076,45 +1076,45 @@ inline void Executor::_invoke_dynamic_task_internal(
 inline void Executor::_invoke_condition_task(
   Worker& worker, Node* node, int& cond
 ) {
-  _observer_prologue(worker, node);
-  cond = std::get<Node::Condition>(node->_handle).work();
-  _observer_epilogue(worker, node);
+    _observer_prologue(worker, node);
+    cond = std::get_if<Node::Condition>(&(node->_handle))->work();
+    _observer_epilogue(worker, node);
 }
 
 // Procedure: _invoke_cudaflow_task
 inline void Executor::_invoke_cudaflow_task(Worker& worker, Node* node) {
-  _observer_prologue(worker, node);  
-  std::get<Node::cudaFlow>(node->_handle).work(*this, node);
-  _observer_epilogue(worker, node);
+    _observer_prologue(worker, node);
+    std::get_if<Node::cudaFlow>(&(node->_handle))->work(*this, node);
+    _observer_epilogue(worker, node);
 }
 
 // Procedure: _invoke_syclflow_task
 inline void Executor::_invoke_syclflow_task(Worker& worker, Node* node) {
-  _observer_prologue(worker, node);  
-  std::get<Node::syclFlow>(node->_handle).work(*this, node);
-  _observer_epilogue(worker, node);
+    _observer_prologue(worker, node);
+    std::get_if<Node::syclFlow>(&(node->_handle))->work(*this, node);
+    _observer_epilogue(worker, node);
 }
 
 // Procedure: _invoke_module_task
 inline void Executor::_invoke_module_task(Worker& w, Node* node) {
   _observer_prologue(w, node);
-  auto module = std::get<Node::Module>(node->_handle).module;
+  auto module = std::get_if<Node::Module>(&(node->_handle))->module;
   _invoke_dynamic_task_internal(w, node, module->_graph, false);
   _observer_epilogue(w, node);  
 }
 
 // Procedure: _invoke_async_task
 inline void Executor::_invoke_async_task(Worker& w, Node* node) {
-  _observer_prologue(w, node);
-  std::get<Node::Async>(node->_handle).work(false);
-  _observer_epilogue(w, node);  
+    _observer_prologue(w, node);
+    std::get_if<Node::Async>(&(node->_handle))->work(false);
+    _observer_epilogue(w, node);
 }
 
 // Procedure: _invoke_silent_async_task
 inline void Executor::_invoke_silent_async_task(Worker& w, Node* node) {
-  _observer_prologue(w, node);
-  std::get<Node::SilentAsync>(node->_handle).work();
-  _observer_epilogue(w, node);  
+    _observer_prologue(w, node);
+    std::get_if<Node::SilentAsync>(&(node->_handle))->work();
+    _observer_epilogue(w, node);
 }
 
 // Function: run
@@ -1446,6 +1446,3 @@ void Subflow::silent_async(F&& f, ArgsT&&... args) {
 
 
 }  // end of namespace tf -----------------------------------------------------
-
-
-


### PR DESCRIPTION
This PR aims to increase the compatibility of the taskflow library with older versions of macOS.
Trying to build Python wheels for our project that incorporates taskflow showed that targeting macOS yields several errors stating that std::variant's `std::get` is not available.
For an example of this see https://github.com/iic-jku/ddsim/runs/3732494041?check_suite_focus=true#step:4:280.

The problem can be resolved by replacing `std::get` calls with the corresponding `std::get_if` equivalent (see also https://stackoverflow.com/a/53887048).