### PR TITLE
Fix minor typos in Cookbook/Executor.

### DIFF
--- a/doxygen/cookbook/executor.dox
+++ b/doxygen/cookbook/executor.dox
@@ -98,7 +98,7 @@ tf::Executor executor;  // create an executor
   // ... 
 
   // run the taskflow
-  executor.run(f);
+  executor.run(taskflow);
 
 } // leaving the scope will destroy taskflow while it is running, 
   // resulting in undefined behavior
@@ -115,10 +115,10 @@ tf::Taskflow taskflow;
 // Declare an executor
 tf::Executor executor;
 
-tf::Future<void> future = taskflow.run(f);  // non-blocking return
+tf::Future<void> future = executor.run(taskflow);  // non-blocking return
 
 // alter the taskflow while running leads to undefined behavior 
-f.emplace([](){ std::cout << "Add a new task\n"; });
+taskflow.emplace([](){ std::cout << "Add a new task\n"; });
 @endcode
 
 You must always keep a taskflow alive and must not modify it while 
@@ -223,7 +223,7 @@ tf::Executor executor(8);                 // an executor of eight workers
 assert(executor.this_worker_id() == -1);  // master thread is not a worker
 
 taskflow.emplace([&](){
-  int id = executor.this_worker_id();     // in the range [0, 8)
+  int worker_id = executor.this_worker_id();     // in the range [0, 8)
   auto& vec = worker_vectors[worker_id];
   // ...
 });


### PR DESCRIPTION
Some variable names in the example seem to have typos.