### PR TITLE
Add ability to set max steals and max yields

### DIFF
--- a/taskflow/core/executor.hpp
+++ b/taskflow/core/executor.hpp
@@ -63,10 +63,14 @@ class Executor {
     or an exception will be thrown.
     By default, the number of worker threads is equal to the maximum
     hardware concurrency returned by std::thread::hardware_concurrency.
+    @param max_steals Sets _MAX_STEALS. Defaults to ((std::thread::hardware_concurrency() + 1) << 1)
+    @param max_yields Sets _MAX_YIELDS. Defaults to 100
     */
     explicit Executor(
       size_t N = std::thread::hardware_concurrency(),
-      std::shared_ptr<WorkerInterface> wix = nullptr 
+      std::shared_ptr<WorkerInterface> wix = nullptr,
+      size_t max_steals = ((std::thread::hardware_concurrency() + 1) << 1),
+      size_t max_yields = 100
     );
 
     /**
@@ -758,9 +762,9 @@ class Executor {
 };
 
 // Constructor
-inline Executor::Executor(size_t N, std::shared_ptr<WorkerInterface> wix) :
-  _MAX_STEALS {((N+1) << 1)},
-  _MAX_YIELDS {100},
+inline Executor::Executor(size_t N, std::shared_ptr<WorkerInterface> wix, size_t max_steals, size_t max_yields) :
+  _MAX_STEALS {max_steals},
+  _MAX_YIELDS {max_yields},
   _threads    {N},
   _workers    {N},
   _notifier   {N},

--- a/taskflow/core/executor.hpp
+++ b/taskflow/core/executor.hpp
@@ -677,9 +677,15 @@ class Executor {
     */
     size_t max_steals() const noexcept;
 
+    /**
+    @brief queries the maximum number of yields before sleeping the thread
+    */
+    size_t max_yields() const noexcept;
+
   private:
     
     const size_t _MAX_STEALS;
+    const size_t _MAX_YIELDS;
 
     std::condition_variable _topology_cv;
     std::mutex _taskflow_mutex;
@@ -754,6 +760,7 @@ class Executor {
 // Constructor
 inline Executor::Executor(size_t N, std::shared_ptr<WorkerInterface> wix) :
   _MAX_STEALS {((N+1) << 1)},
+  _MAX_YIELDS {100},
   _threads    {N},
   _workers    {N},
   _notifier   {N},
@@ -795,6 +802,11 @@ inline size_t Executor::num_workers() const noexcept {
 // Function: max_steals
 inline size_t Executor::max_steals() const noexcept {
   return _MAX_STEALS;
+}
+
+// Function: max_yields
+inline size_t Executor::max_yields() const noexcept {
+  return _MAX_YIELDS;
 }
 
 // Function: num_topologies
@@ -1032,7 +1044,7 @@ inline void Executor::_explore_task(Worker& w, Node*& t) {
 
     if(num_steals++ > _MAX_STEALS) {
       std::this_thread::yield();
-      if(num_yields++ > 100) {
+      if(num_yields++ > _MAX_YIELDS) {
         break;
       }
     }


### PR DESCRIPTION
When profiling our application that uses Taskflow, we noticed that `std::this_thread::yield();` was causing a lot of cpu spin time. After discussing with @tsung-wei-huang, it sounds like the main problem was that our system uses multiple executors in order to keep resources independent for different types of tasks. He suggested that we try to reduce the number of executors and also that we adjust the max steals and max yields. After testing reducing the max yields and max steals (first 2 commits), this didn't seem to have much of an impact on spin time. As a result, I added an optional sleep after max yields is reached (3rd commit). This does reduce the spin time.

This PR adds the ability to set the max steals, max yields, and the sleep duration after those are reached. The defaults should work the same as before if you were using all default arguments for the executor. If you were passing in the number of threads (N), simply pass in ((N + 1) << 1) for max steals to maintain the same behavior.