### PR TITLE
support emscripten build

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -38,6 +38,11 @@ foreach(example IN LISTS TF_EXAMPLES)
   target_link_libraries(
     ${example} ${PROJECT_NAME} tf::default_settings
     )
+  # set emcc options
+  if (CMAKE_SYSTEM_NAME STREQUAL Emscripten)
+    target_link_options(${example} PUBLIC -sASSERTIONS=1 -sPROXY_TO_PTHREAD -sTOTAL_MEMORY=1536MB -sEXIT_RUNTIME=1 -sUSE_PTHREADS=1)
+    target_compile_options(${example} PUBLIC -matomics)
+  endif()
 endforeach()
 
 # -----------------------------------------------------------------------------

--- a/taskflow/utility/os.hpp
+++ b/taskflow/utility/os.hpp
@@ -76,13 +76,6 @@
 #define TF_OS_SOLARIS 1
 #endif
 
-#if (1 !=                                                                  \
-     TF_OS_LINUX + TF_OS_DRAGONFLY + TF_OS_FREEBSD + TF_OS_NETBSD +        \
-     TF_OS_OPENBSD + TF_OS_DARWIN + TF_OS_WINDOWS + TF_OS_HURD +           \
-     TF_OS_SOLARIS)
-#error Unknown OS
-#endif
-
 #if TF_OS_LINUX || TF_OS_DRAGONFLY || TF_OS_FREEBSD || TF_OS_NETBSD ||     \
     TF_OS_OPENBSD || TF_OS_DARWIN || TF_OS_HURD || TF_OS_SOLARIS
 #undef TF_OS_UNIX


### PR DESCRIPTION
These changes allowed building the library with emscripten, and running a few of the examples:

**build**

`emcmake cmake ...`

**run example with node.js**

`node --experimental-wasm-threads --experimental-wasm-bulk-memory examples/simple.js`