### PR TITLE
fix compile command

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ tell the compiler to include the [headers](./taskflow/).
 
 ```bash
 ~$ git clone https://github.com/taskflow/taskflow.git  # clone it only once
-~$ g++ -std=c++17 simple.cpp -I taskflow/taskflow -O2 -pthread -o simple
+~$ g++ -std=c++17 simple.cpp -I taskflow -O2 -pthread -o simple
 ~$ ./simple
 TaskA
 TaskC 

--- a/docs/index.html
+++ b/docs/index.html
@@ -131,7 +131,7 @@
 
 <span class="w">  </span><span class="k">return</span><span class="w"> </span><span class="mi">0</span><span class="p">;</span><span class="w"></span>
 <span class="p">}</span><span class="w"></span></pre><p>Taskflow is <em>header-only</em> and there is no wrangle with installation. To compile the program, clone the Taskflow project and tell the compiler to include the headers under <code>taskflow/</code>.</p><pre class="m-console"><span class="go">~$ git clone https://github.com/taskflow/taskflow.git  # clone it only once</span>
-<span class="go">~$ g++ -std=c++17 simple.cpp -I taskflow/taskflow -O2 -pthread -o simple</span>
+<span class="go">~$ g++ -std=c++17 simple.cpp -I taskflow -O2 -pthread -o simple</span>
 <span class="go">~$ ./simple</span>
 <span class="go">TaskA</span>
 <span class="go">TaskC </span>


### PR DESCRIPTION
because there is`#include <taskflow/taskflow.hpp>`  in your simple.cpp, g++ doesn't need to specify another taskflow directory as -I parameter.
for example, when I run:
```bash
g++ -std=c++17 simple.cpp -I taskflow/taskflow -O2 -pthread -o simple
```
I receive this error message:
```
simple.cpp:1:10: fatal error: taskflow/taskflow.hpp: No such file or directory
    1 | #include <taskflow/taskflow.hpp>  // Taskflow is header-only
      |
```