### PR TITLE
[RFC] Fix unnecessary busy waiting when no new tasks are incoming

### DIFF
--- a/taskflow/core/executor.hpp
+++ b/taskflow/core/executor.hpp
@@ -549,6 +549,14 @@ class Executor {
     size_t num_thieves() const;
 
     /**
+    @brief queries the number of workers that are waiting
+
+    The function returns the current number of workers that are neither actively processing
+    tasks, nor stealing them, nor in transition state between the two.
+    */
+    size_t num_waiting() const;
+
+    /**
     @brief queries the id of the caller thread in this executor
 
     Each worker has an unique id in the range of @c 0 to @c N-1 associated with
@@ -835,6 +843,11 @@ inline size_t Executor::num_taskflows() const {
 inline size_t Executor::num_thieves() const {
   return _num_thieves;
 } 
+
+// Function: num_waiting
+inline size_t Executor::num_waiting() const {
+  return _notifier.num_committed_waiters();
+}
 
 // Function: _this_worker
 inline Worker* Executor::_this_worker() {


### PR DESCRIPTION
Currently if there is a long-running task that does not itself produce additional tasks there will be one thread doing busy waiting because it won't be able to park. This is because if the thread is the last one without tasks (_num_thieves == 1), then parking can only happen if _num_actives == 0.

This check is to prevent missed wakeups that are initiated in _exploit_task(). The same can be achieved by enhancing the condition to specifically check for transition of _num_actives from 0 to nonzero. This allows the thread to park and avoids busy waiting.

The change removes the guarantee that when _num_actives changes from 0 to 1 and the last thief thread is in the process of parking, then this parking will be cancelled. It's possible, that between `_num_actives.load()` and `if(prev_num_actives == 0 && _num_actives)` the value of _num_actives goes from 1 to 0 and back to 1 due to different threads exiting and entering _exploit_task().

This is a rare occurrence and rather harmless, because even if the thread mistakenly parked itself, it verified that the queues are empty just before doing so. Any new items in the queues will wake up at least one thread anyway.


To give some hard numbers, I'm working with an application that has long periods of time when only single task is active. When testing on a Samsung S10 phone I saw around 30% performance improvement with this fix and reduction of CPU usage from 200% to 100% during the periods of time when only single task is active. The performance improvement is due to higher boost clocks when only single thread is active and also due to being able to keep high frequencies for longer without throttling.

This PR needs testing on a wider set of test scenarios. Could you point me to test suites that you usually run to verify that there are no performance regressions?