### PR TITLE
Improve inlining of critical functions of TaskQueue

### DIFF
--- a/taskflow/core/tsq.hpp
+++ b/taskflow/core/tsq.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../utility/macros.hpp"
 #include "../utility/traits.hpp"
 
 /**
@@ -213,7 +214,7 @@ class TaskQueue {
     The operation can trigger the queue to resize its capacity
     if more space is required.
     */
-    void push(T item, unsigned priority = 0);
+    TF_FORCE_INLINE void push(T item, unsigned priority = 0);
 
     /**
     @brief pops out an item from the queue
@@ -250,6 +251,9 @@ class TaskQueue {
     The return can be a @c nullptr if this operation failed (not necessary empty).
     */
     T steal(unsigned priority);
+
+  private:
+    TF_NO_INLINE Array* resize_array(Array* a, unsigned p, std::int64_t b, std::int64_t t);
 };
 
 // Constructor
@@ -312,7 +316,7 @@ size_t TaskQueue<T, MAX_PRIORITY>::size(unsigned p) const noexcept {
 
 // Function: push
 template <typename T, unsigned MAX_PRIORITY>
-void TaskQueue<T, MAX_PRIORITY>::push(T o, unsigned p) {
+TF_FORCE_INLINE void TaskQueue<T, MAX_PRIORITY>::push(T o, unsigned p) {
 
   int64_t b = _bottom[p].data.load(std::memory_order_relaxed);
   int64_t t = _top[p].data.load(std::memory_order_acquire);
@@ -320,12 +324,7 @@ void TaskQueue<T, MAX_PRIORITY>::push(T o, unsigned p) {
 
   // queue is full
   if(a->capacity() - 1 < (b - t)) {
-    Array* tmp = a->resize(b, t);
-    _garbage[p].push_back(a);
-    std::swap(a, tmp);
-    _array[p].store(a, std::memory_order_release);
-    // Note: the original paper using relaxed causes t-san to complain
-    //_array.store(a, std::memory_order_relaxed);
+    a = resize_array(a, p, b, t);
   }
 
   a->push(b, o);
@@ -424,5 +423,19 @@ template <typename T, unsigned MAX_PRIORITY>
 int64_t TaskQueue<T, MAX_PRIORITY>::capacity(unsigned p) const noexcept {
   return _array[p].load(std::memory_order_relaxed)->capacity();
 }
+
+template <typename T, unsigned MAX_PRIORITY>
+TF_NO_INLINE typename TaskQueue<T, MAX_PRIORITY>::Array*
+  TaskQueue<T, MAX_PRIORITY>::resize_array(Array* a, unsigned p, std::int64_t b, std::int64_t t) {
+
+  Array* tmp = a->resize(b, t);
+  _garbage[p].push_back(a);
+  std::swap(a, tmp);
+  _array[p].store(a, std::memory_order_release);
+  // Note: the original paper using relaxed causes t-san to complain
+  //_array.store(a, std::memory_order_relaxed);
+  return a;
+}
+
 
 }  // end of namespace tf -----------------------------------------------------

--- a/taskflow/core/tsq.hpp
+++ b/taskflow/core/tsq.hpp
@@ -232,7 +232,7 @@ class TaskQueue {
     Only the owner thread can pop out an item from the queue.
     The return can be a @c nullptr if this operation failed (empty queue).
     */
-    T pop(unsigned priority);
+    TF_FORCE_INLINE T pop(unsigned priority);
 
     /**
     @brief steals an item from the queue
@@ -345,7 +345,7 @@ T TaskQueue<T, MAX_PRIORITY>::pop() {
 
 // Function: pop
 template <typename T, unsigned MAX_PRIORITY>
-T TaskQueue<T, MAX_PRIORITY>::pop(unsigned p) {
+TF_FORCE_INLINE T TaskQueue<T, MAX_PRIORITY>::pop(unsigned p) {
 
   int64_t b = _bottom[p].data.load(std::memory_order_relaxed) - 1;
   Array* a = _array[p].load(std::memory_order_relaxed);

--- a/taskflow/utility/macros.hpp
+++ b/taskflow/utility/macros.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#if defined(_MSC_VER)
+  #define TF_FORCE_INLINE __forceinline
+#elif defined(__GNUC__) && __GNUC__ > 3
+  #define TF_FORCE_INLINE __attribute__((__always_inline__)) inline
+#else
+  #define TF_FORCE_INLINE inline
+#endif
+
+#if defined(_MSC_VER)
+  #define TF_NO_INLINE __declspec(noinline)
+#elif defined(__GNUC__) && __GNUC__ > 3
+  #define TF_NO_INLINE __attribute__((__noinline__))
+#else
+  #define TF_NO_INLINE
+#endif


### PR DESCRIPTION
`TaskQueue::push()` and `TaskQueue::pop()` are functions that are in critical hot code path and used only from few places. It makes sense to look into improving inlining decisions for these functions.

As compiled on x86_64 by gcc 10.2, `TaskQueue::push()` contains a number of function prologue and epilogue instructions. These are mostly needed for the case when the queue overflows and needs resizing, which happens extremely infrequently. Inlining the frequent code path and forbidding inlining of the infrequent code path should improve performance slightly.

`TaskQueue::pop()` on the other hand does not have much in function prologue and epilogue as it fits into caller-saved registers. However, the function is called from only 2 places, so inlining it too does not increase binary size too much yet should allow better register usage in the caller.

Preliminary testing shows that these optimizations lead to up to 0.5% faster benchmarks (depends on benchmark). I will provide full result spreadsheet when I run the benchmarks enough times.