### PR TITLE
Fix duplicate symbol errors in benchmarks

### DIFF
--- a/benchmarks/data_pipeline/taskflow.cpp
+++ b/benchmarks/data_pipeline/taskflow.cpp
@@ -2,6 +2,8 @@
 #include <taskflow/taskflow.hpp>
 #include <taskflow/algorithm/data_pipeline.hpp>
 
+namespace {
+
 //my convert function
 auto int2string = [](int& input) -> std::string {
   work_int(input);
@@ -577,6 +579,8 @@ std::chrono::microseconds parallel_pipeline_taskflow_16_pipes(
   auto end = std::chrono::high_resolution_clock::now();
   return std::chrono::duration_cast<std::chrono::microseconds>(end - beg);
 }
+
+} // namespace
 
 std::chrono::microseconds measure_time_taskflow(
   std::string pipes, unsigned num_lines, unsigned num_threads, size_t size) {

--- a/benchmarks/data_pipeline/tbb.cpp
+++ b/benchmarks/data_pipeline/tbb.cpp
@@ -8,6 +8,8 @@
 #include <vector>
 #include <cmath>
 
+namespace {
+
 size_t i = 0;
 
 // Filter for one filter only
@@ -471,6 +473,8 @@ void parallel_pipeline_tbb_16_pipes(std::string pipes, unsigned num_lines, size_
       pipes[15] == 's' ? tbb::filter::serial_in_order : tbb::filter::parallel, int2void)
   );
 }
+
+} // namespace
 
 std::chrono::microseconds measure_time_tbb(
   std::string pipes, unsigned num_lines, unsigned num_threads, size_t size) {


### PR DESCRIPTION
data_pipeline benchmark contains multiple definitions of the same symbol with external linkage, which causes link-time errors on Linux.