### PR TITLE
Update cmake minimum version to 3.18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 
 
 # CMake version
-cmake_minimum_required (VERSION 3.12)
+cmake_minimum_required (VERSION 3.18)
 MESSAGE(STATUS "CMAKE_ROOT: " ${CMAKE_ROOT})
 
 # Project name


### PR DESCRIPTION
Current cmake minimum version is set to cmake 3.12 in CMakeLists.txt. This version allows to define `CMAKE_CUDA_STANDARD` up to 14. Support for `CMAKE_CUDA_STANDARD` 17 and 20 have only been introduced recently in cmake 3.18.