### PR TITLE
Update compatibility guarantees

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -364,7 +364,7 @@ configure_package_config_file(
 
 write_basic_package_version_file(
   ${PROJECT_NAME}ConfigVersion.cmake 
-  COMPATIBILITY SameMajorVersion
+  COMPATIBILITY SameMinorVersion
 )
 
 install(


### PR DESCRIPTION
There are breaking changes in many minor Version upgrades, so the compatibility is really only between minor versions.

E.g. Version 3.6 introduced a couple oft breaking changes leading to build errors downstream https://github.com/maxbachmann/RapidFuzz/issues/329