### PR TITLE
Add a function to cancel the precedence relationship between two tasks.

### DIFF
--- a/taskflow/core/taskflow.hpp
+++ b/taskflow/core/taskflow.hpp
@@ -255,6 +255,13 @@ class Taskflow : public FlowBuilder {
     */
     Graph& graph();
 
+    /**
+    @brief 
+
+    Cancel the precedence relationship between two tasks.
+    */
+    void connectDecre(Task dep, Task cuc);
+
   private:
 
     mutable std::mutex _mutex;
@@ -358,6 +365,29 @@ inline void Taskflow::dump(std::ostream& os) const {
   os << "digraph Taskflow {\n";
   _dump(os, &_graph);
   os << "}\n";
+}
+
+// Function: connectDecre
+inline void Taskflow::connectDecre(Task dep, Task cuc) {
+    if (!dep._node || !cuc._node) {
+        return;
+    }
+
+    auto& S = dep._node->_successors;
+    for (auto I = S.begin(); I < S.end(); I++) {
+        if (*I == cuc._node) {
+            S.erase(I);
+            break;
+        }
+    }
+
+    auto& D = cuc._node->_dependents;
+    for (auto I = D.begin(); I < D.end(); I++) {
+        if (*I == dep._node) {
+            D.erase(I);
+            break;
+        }
+    }
 }
 
 // Procedure: _dump

--- a/unittests/test_basics.cpp
+++ b/unittests/test_basics.cpp
@@ -169,6 +169,26 @@ TEST_CASE("Builder" * doctest::timeout(300)) {
     REQUIRE(taskflow.num_tasks() == num_tasks);
   }
 
+  SUBCASE("Connect Decrement") {
+      for (size_t i = 0; i < num_tasks; i++) {
+          tasks.emplace_back(
+              taskflow.emplace([&counter, i]() {
+                 counter += 1; }
+              )
+          );
+          if (i > 0) {
+              tasks[i - 1].precede(tasks[i]);
+              taskflow.connectDecre(tasks[i - 1], tasks[i]);
+          }
+      }
+      for (size_t i = 0; i < num_tasks; ++i) {
+          REQUIRE(tasks[i].num_dependents() == 0);
+          REQUIRE(tasks[i].num_successors() == 0);
+      }
+      executor.run(taskflow).get();
+      REQUIRE(taskflow.num_tasks() == num_tasks);
+  }
+
   SUBCASE("MapReduce"){
 
     auto src = taskflow.emplace([&counter]() {counter = 0;});


### PR DESCRIPTION
I am writing a data flow gui. The bottom layer of each node corresponds to a task in taskflow. I want to map the connection and disconnection operations of the nodes on the gui to tasks in taskflow. Because taskflow already has the precede and succeed interfaces corresponding to the connection operation, I add a function called `void connectDecre(Task dep, Task cuc) ` which is implemented to cancel the connection. 
I don't know if this function is necessary at the level of the entire project. If it doesn't meet the design intent and this pull request is unreasonable, I may need to separate my own data flow structure of the gui from the taskflow structure. The data flow structure of gui  can be dynamically operated, and then it is parsed into taskflow when it is finally executed. Or I just use inheritance method or additional code to meet my own needs.