### PR TITLE
Add task_wrapper for for_each, for_each_index, transform and find_if …

### DIFF
--- a/taskflow/algorithm/for_each.hpp
+++ b/taskflow/algorithm/for_each.hpp
@@ -1,18 +1,20 @@
 #pragma once
 
 #include "launch.hpp"
+#include "../core/task_wrapper.hpp"
 
 namespace tf {
 
 // Function: make_for_each_task
-template <typename B, typename E, typename C, typename P = GuidedPartitioner>
-TF_FORCE_INLINE auto make_for_each_task(B b, E e, C c, P&& part = P()) {
-  
+template <typename B, typename E, typename C, typename P = GuidedPartitioner, typename TW = TaskWrapperIdent>
+TF_FORCE_INLINE auto make_for_each_task(B b, E e, C c, P &&part = P(), TW &&task_wrapper = TW())
+{
+
   using B_t = std::decay_t<unwrap_ref_decay_t<B>>;
   using E_t = std::decay_t<unwrap_ref_decay_t<E>>;
   using namespace std::string_literals;
 
-  return [b, e, c, part=std::forward<P>(part)] (Runtime& rt) mutable {
+  return [b, e, c, task_wrapper, part=std::forward<P>(part)] (Runtime& rt) mutable {
 
     // fetch the stateful values
     B_t beg = b;
@@ -23,7 +25,9 @@ TF_FORCE_INLINE auto make_for_each_task(B b, E e, C c, P&& part = P()) {
 
     // only myself - no need to spawn another graph
     if(W <= 1 || N <= part.chunk_size()) {
-      std::for_each(beg, end, c);
+      task_wrapper([&](){
+        std::for_each(beg, end, c);
+      });
       return;
     }
 
@@ -36,8 +40,29 @@ TF_FORCE_INLINE auto make_for_each_task(B b, E e, C c, P&& part = P()) {
       size_t chunk_size;
       for(size_t w=0, curr_b=0; w<W && curr_b < N; ++w, curr_b += chunk_size) {
         chunk_size = part.adjusted_chunk_size(N, W, w);
-        launch_loop(W, w, rt, [=, &c, &part] () mutable {
-          part.loop(N, W, curr_b, chunk_size,
+        launch_loop(W, w, rt, [=, &c, &part,&task_wrapper] () mutable {
+          task_wrapper([&]{
+            part.loop(N, W, curr_b, chunk_size,
+              [&, prev_e=size_t{0}](size_t part_b, size_t part_e) mutable {
+                std::advance(beg, part_b - prev_e);
+                for(size_t x = part_b; x<part_e; x++) {
+                  c(*beg++);
+                }
+                prev_e = part_e;
+              }
+            ); 
+          });
+        });
+      }
+
+      rt.corun_all();
+    }
+    // dynamic partitioner
+    else {
+      std::atomic<size_t> next(0);
+      launch_loop(N, W, rt, next, part, [=, &c, &next, &part,&task_wrapper] () mutable {
+        task_wrapper([&]() {
+          part.loop(N, W, next, 
             [&, prev_e=size_t{0}](size_t part_b, size_t part_e) mutable {
               std::advance(beg, part_b - prev_e);
               for(size_t x = part_b; x<part_e; x++) {
@@ -47,31 +72,14 @@ TF_FORCE_INLINE auto make_for_each_task(B b, E e, C c, P&& part = P()) {
             }
           ); 
         });
-      }
-
-      rt.corun_all();
-    }
-    // dynamic partitioner
-    else {
-      std::atomic<size_t> next(0);
-      launch_loop(N, W, rt, next, part, [=, &c, &next, &part] () mutable {
-        part.loop(N, W, next, 
-          [&, prev_e=size_t{0}](size_t part_b, size_t part_e) mutable {
-            std::advance(beg, part_b - prev_e);
-            for(size_t x = part_b; x<part_e; x++) {
-              c(*beg++);
-            }
-            prev_e = part_e;
-          }
-        ); 
       });
     }
   };
 }
 
 // Function: make_for_each_index_task
-template <typename B, typename E, typename S, typename C, typename P = GuidedPartitioner>
-TF_FORCE_INLINE auto make_for_each_index_task(B b, E e, S s, C c, P&& part = P()) {
+template <typename B, typename E, typename S, typename C, typename P = GuidedPartitioner, typename TW = TaskWrapperIdent>
+TF_FORCE_INLINE auto make_for_each_index_task(B b, E e, S s, C c, P&& part = P(), TW&&task_wrapper = TW()){
 
   using namespace std::string_literals;
 
@@ -79,7 +87,8 @@ TF_FORCE_INLINE auto make_for_each_index_task(B b, E e, S s, C c, P&& part = P()
   using E_t = std::decay_t<unwrap_ref_decay_t<E>>;
   using S_t = std::decay_t<unwrap_ref_decay_t<S>>;
 
-  return [b, e, s, c, part=std::forward<P>(part)] (Runtime& rt) mutable {
+  return [b, e, s, c, part=std::forward<P>(part), task_wrapper=std::forward<TW>(task_wrapper)] 
+  (Runtime& rt) mutable {
 
     // fetch the iterator values
     B_t beg = b;
@@ -96,10 +105,12 @@ TF_FORCE_INLINE auto make_for_each_index_task(B b, E e, S s, C c, P&& part = P()
 
     // only myself - no need to spawn another graph
     if(W <= 1 || N <= part.chunk_size()) {
-      for(size_t x=0; x<N; x++, beg+=inc) {
-        c(beg);
-      }
-      return;
+        task_wrapper([&](){
+          for(size_t x=0; x<N; x++, beg+=inc) {
+            c(beg);
+          }
+        });
+        return;
     }
 
     if(N < W) {
@@ -111,15 +122,17 @@ TF_FORCE_INLINE auto make_for_each_index_task(B b, E e, S s, C c, P&& part = P()
       size_t chunk_size;
       for(size_t w=0, curr_b=0; w<W && curr_b < N; ++w, curr_b += chunk_size) {
         chunk_size = part.adjusted_chunk_size(N, W, w);
-        launch_loop(W, w, rt, [=, &c, &part] () mutable {
-          part.loop(N, W, curr_b, chunk_size,
-            [&](size_t part_b, size_t part_e) {
-              auto idx = static_cast<B_t>(part_b) * inc + beg;
-              for(size_t x=part_b; x<part_e; x++, idx += inc) {
-                c(idx);
+        launch_loop(W, w, rt, [=, &c, &part, &task_wrapper] () mutable {
+          task_wrapper([&]{
+            part.loop(N, W, curr_b, chunk_size,
+              [&](size_t part_b, size_t part_e) {
+                auto idx = static_cast<B_t>(part_b) * inc + beg;
+                for(size_t x=part_b; x<part_e; x++, idx += inc) {
+                  c(idx);
+                }
               }
-            }
-          ); 
+            ); 
+          });
         });
       }
 
@@ -128,15 +141,17 @@ TF_FORCE_INLINE auto make_for_each_index_task(B b, E e, S s, C c, P&& part = P()
     // dynamic partitioner
     else {
       std::atomic<size_t> next(0);
-      launch_loop(N, W, rt, next, part, [=, &c, &next, &part] () mutable {
-        part.loop(N, W, next, 
-          [&](size_t part_b, size_t part_e) {
-            auto idx = static_cast<B_t>(part_b) * inc + beg;
-            for(size_t x=part_b; x<part_e; x++, idx += inc) {
-              c(idx);
+      launch_loop(N, W, rt, next, part, [=, &c, &next, &part, &task_wrapper] () mutable {
+        task_wrapper([&]() mutable {
+          part.loop(N, W, next, 
+            [&](size_t part_b, size_t part_e) {
+              auto idx = static_cast<B_t>(part_b) * inc + beg;
+              for(size_t x=part_b; x<part_e; x++, idx += inc) {
+                c(idx);
+              }
             }
-          }
-        ); 
+          ); 
+        });
       });
     }
   };
@@ -147,10 +162,10 @@ TF_FORCE_INLINE auto make_for_each_index_task(B b, E e, S s, C c, P&& part = P()
 // ----------------------------------------------------------------------------
 
 // Function: for_each
-template <typename B, typename E, typename C, typename P>
-Task FlowBuilder::for_each(B beg, E end, C c, P&& part) {
+template <typename B, typename E, typename C, typename P, typename W>
+Task FlowBuilder::for_each(B beg, E end, C c, P&& part, W&&task_wrapper) {
   return emplace(
-    make_for_each_task(beg, end, c, std::forward<P>(part))
+    make_for_each_task(beg, end, c, std::forward<P>(part), std::forward<W>(task_wrapper))
   );
 }
 
@@ -159,10 +174,10 @@ Task FlowBuilder::for_each(B beg, E end, C c, P&& part) {
 // ----------------------------------------------------------------------------
 
 // Function: for_each_index
-template <typename B, typename E, typename S, typename C, typename P>
-Task FlowBuilder::for_each_index(B beg, E end, S inc, C c, P&& part) {
+template <typename B, typename E, typename S, typename C, typename P, typename W>
+Task FlowBuilder::for_each_index(B beg, E end, S inc, C c, P&& part, W&& task_wrapper){
   return emplace(
-    make_for_each_index_task(beg, end, inc, c, std::forward<P>(part))
+    make_for_each_index_task(beg, end, inc, c, std::forward<P>(part), std::forward<W>(task_wrapper))
   );
 }
 

--- a/taskflow/core/task_wrapper.hpp
+++ b/taskflow/core/task_wrapper.hpp
@@ -1,0 +1,20 @@
+  #pragma once
+
+  /**
+   * @file task_wrapper.hpp
+   * @brief task wrapper include file
+   * 
+   */
+
+  namespace tf {
+
+  /**
+   * @brief performs an identity wrapping of a function object
+   * 
+   */
+  struct TaskWrapperIdent {
+    template <typename Task>
+    void operator()(Task&& task) const { std::forward<Task>(task)(); }
+  };
+
+  }

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -3,6 +3,7 @@ enable_testing()
 include(${TF_3RD_PARTY_DIR}/doctest/doctest.cmake)
 
 list(APPEND TF_UNITTESTS 
+  test_chunk_context
   test_utility 
   test_work_stealing 
   #test_serializer 

--- a/unittests/test_chunk_context.cpp
+++ b/unittests/test_chunk_context.cpp
@@ -1,0 +1,289 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+
+#include <doctest.h>
+#include <taskflow/taskflow.hpp>
+#include <taskflow/algorithm/for_each.hpp>
+#include <taskflow/algorithm/transform.hpp>
+#include <taskflow/algorithm/find.hpp>
+#include <iostream>
+#include <mutex>
+
+namespace
+{
+  int& GetThreadSpecificContext()
+  {
+      thread_local int context = 0;
+      return context;
+  }
+
+  const int UPPER = 1000;
+}
+
+// --------------------------------------------------------
+// Testcase: chunk context
+// --------------------------------------------------------
+
+// ChunkContext
+TEST_CASE("Chunk.Context.for_each_index.static" * doctest::timeout(300))
+{
+  for (int tc = 4; tc < 64; tc++)
+  {
+    tf::Executor executor(tc);
+    std::atomic<int> wrapper_called_count = 0;
+    auto task_wrapper = [&](auto &&task)
+    {
+      wrapper_called_count++;
+      GetThreadSpecificContext() = tc;
+      task();
+      GetThreadSpecificContext() = 0;
+    };
+    std::atomic<int> count = 0;
+    tf::Taskflow taskflow;
+    std::vector<int> range(100, 0);
+    taskflow.for_each_index(
+        0, 100, 1, [&](int i)
+		{ count++; range[i] = GetThreadSpecificContext(); },
+        tf::StaticPartitioner(1), task_wrapper);
+    executor.run(taskflow).wait();
+
+    REQUIRE(count == 100);
+    REQUIRE(range == std::vector<int>(100, tc));
+    REQUIRE(wrapper_called_count == tc);
+  }
+}
+
+// ChunkContext
+TEST_CASE("Chunk.Context.for_each_index.dynamic" * doctest::timeout(300))
+{
+  for (int tc = 4; tc < 64; tc++)
+  {
+    tf::Executor executor(tc);
+    std::atomic<int> wrapper_called_count = 0;
+    auto task_wrapper = [&](auto &&task)
+    {
+      wrapper_called_count++;
+      GetThreadSpecificContext() = tc;
+      task();
+      GetThreadSpecificContext() = 0;
+    };
+    std::atomic<int> count = 0;
+    std::vector<int> range(UPPER, 0);
+    tf::Taskflow taskflow;
+    taskflow.for_each_index(
+        0, UPPER, 1, [&](int i)
+        { count++; range[i] = GetThreadSpecificContext();
+        },
+        tf::DynamicPartitioner(UPPER/tc/2), task_wrapper);
+    executor.run(taskflow).wait();
+
+    REQUIRE(count == UPPER);
+    REQUIRE(range == std::vector<int>(UPPER, tc));
+    // Dynamic partitioner will spawn sometimes less tasks
+    REQUIRE(wrapper_called_count <= tc);
+  }
+}
+
+
+TEST_CASE("Chunk.Context.for_each.static" * doctest::timeout(300))
+{
+  for (int tc = 4; tc < 16; tc++)
+  {
+    tf::Executor executor(tc);
+    std::atomic<int> wrapper_called_count = 0;
+    auto task_wrapper = [&](auto &&task)
+    {
+      wrapper_called_count++;
+      GetThreadSpecificContext() = tc;
+      task();
+      GetThreadSpecificContext() = 0;
+    };
+    std::atomic<int> count = 0;
+    tf::Taskflow taskflow;
+    std::vector<int> range(UPPER, 0);
+    taskflow.for_each(
+        begin(range), end(range), [&](int& i)
+        { count++; i = GetThreadSpecificContext(); },
+        tf::StaticPartitioner(1), task_wrapper);
+    executor.run(taskflow).wait();
+
+    REQUIRE(count == UPPER);
+    REQUIRE(range == std::vector<int>(UPPER, tc));
+    REQUIRE(wrapper_called_count == tc);
+  }
+}
+
+TEST_CASE("Chunk.Context.for_each.dynamic" * doctest::timeout(300))
+{
+  for (int tc = 4; tc < 16; tc++)
+  {
+    tf::Executor executor(tc);
+    std::atomic<int> wrapper_called_count = 0;
+
+    auto task_wrapper = [&](auto &&task)
+    {
+      wrapper_called_count++;
+      GetThreadSpecificContext() = tc;
+      task();
+      GetThreadSpecificContext() = 0;
+    };
+    tf::Taskflow taskflow;
+    std::vector<int> range(UPPER, 0);
+    taskflow.for_each(
+        begin(range), end(range), [](int& i)
+        { i = GetThreadSpecificContext(); },
+        tf::DynamicPartitioner(1), task_wrapper);
+    executor.run(taskflow).wait();
+
+    REQUIRE(range == std::vector<int>(UPPER, tc));
+    REQUIRE(wrapper_called_count <= tc); // Dynamic scheduling is not obliged to load all threads with iterations, so <= is appropriate here
+  }
+}
+
+TEST_CASE("Chunk.Context.transform.static" * doctest::timeout(300))
+{
+  // Write a test case for using the taskwrapper on tf::transform
+  for (int tc = 4; tc < 16; tc++)
+  {
+    tf::Executor executor(tc);
+    std::atomic<int> wrapper_called_count = 0;
+    auto task_wrapper = [&](auto &&task)
+    {
+      wrapper_called_count++;
+      GetThreadSpecificContext() = tc;
+      task();
+      GetThreadSpecificContext() = 0;
+    };
+    std::atomic<int> count = 0;
+    tf::Taskflow taskflow;
+    std::vector<int> range(UPPER, 0);
+    std::vector<int> result(UPPER);
+    taskflow.transform(
+        begin(range), end(range), begin(result), [&](int)
+        { return GetThreadSpecificContext(); },
+        tf::StaticPartitioner(1), task_wrapper);
+    executor.run(taskflow).wait();
+
+    REQUIRE(wrapper_called_count == tc);
+    REQUIRE(result == std::vector<int>(UPPER, tc));
+  }
+}
+
+// Implement for dynamic case for transform
+TEST_CASE("Chunk.Context.transform.dynamic" * doctest::timeout(300))
+{
+  for (int tc = 4; tc < 16; tc++)
+  {
+    tf::Executor executor(tc);
+    std::atomic<int> wrapper_called_count = 0;
+    auto task_wrapper = [&](auto &&task)
+    {
+      wrapper_called_count++;
+      GetThreadSpecificContext() = tc;
+      task();
+      GetThreadSpecificContext() = 0;
+    };
+    std::atomic<int> count = 0;
+    tf::Taskflow taskflow;
+    std::vector<int> range(UPPER);
+    std::iota(range.begin(), range.end(), 0);
+    std::vector<int> result(UPPER);
+    taskflow.transform(
+        begin(range), end(range), begin(result), [&](int)
+        { return GetThreadSpecificContext(); },
+        tf::DynamicPartitioner(1), task_wrapper);
+    executor.run(taskflow).wait();
+
+    REQUIRE(wrapper_called_count <= tc);
+    REQUIRE(result == std::vector<int>(UPPER, tc));
+  }
+}
+
+// write a test for find using static partitioner
+TEST_CASE("Chunk.Context.find.static" * doctest::timeout(300))
+{
+  for (int tc = 4; tc < 16; tc++)
+  {
+    tf::Executor executor(tc);
+    std::atomic<int> wrapper_called_count = 0;
+    auto task_wrapper = [&](auto &&task)
+    {
+      wrapper_called_count++;
+      GetThreadSpecificContext() = tc;
+      task();
+      GetThreadSpecificContext() = 0;
+    };
+    std::atomic<int> count = 0;
+    tf::Taskflow taskflow;
+    std::vector<int> range(UPPER);
+    std::vector<int>::iterator result;
+    std::iota(range.begin(), range.end(), 0);
+    taskflow.find_if(
+        begin(range), end(range), result, [&](int i)
+        { return i == 500 && GetThreadSpecificContext() == tc; },
+        tf::StaticPartitioner(1), task_wrapper);
+    executor.run(taskflow).wait();
+
+    REQUIRE(wrapper_called_count == tc);
+    REQUIRE(*result == 500);
+  }
+}
+
+// Same as above testcase but with dynamic partitioner
+TEST_CASE("Chunk.Context.find.dynamic" * doctest::timeout(300))
+{
+  for (int tc = 4; tc < 16; tc++)
+  {
+    tf::Executor executor(tc);
+    std::atomic<int> wrapper_called_count = 0;
+    auto task_wrapper = [&](auto &&task)
+    {
+      wrapper_called_count++;
+      GetThreadSpecificContext() = tc;
+      task();
+      GetThreadSpecificContext() = 0;
+    };
+    std::atomic<int> count = 0;
+    tf::Taskflow taskflow;
+    std::vector<int> range(UPPER);
+    std::vector<int>::iterator result;
+    std::iota(range.begin(), range.end(), 0);
+    taskflow.find_if(
+        begin(range), end(range), result, [&](int i)
+        { return i == 500 && GetThreadSpecificContext() == tc; },
+        tf::DynamicPartitioner(1), task_wrapper);
+    executor.run(taskflow).wait();
+
+    REQUIRE(wrapper_called_count <= tc);
+    REQUIRE(*result == 500);
+  }
+}
+
+// dynamic and static partitioner for find_if_not
+TEST_CASE("Chunk.Context.find_if_not.static" * doctest::timeout(300))
+{
+  for (int tc = 4; tc < 16; tc++)
+  {
+    tf::Executor executor(tc);
+    std::atomic<int> wrapper_called_count = 0;
+    auto task_wrapper = [&](auto &&task)
+    {
+      wrapper_called_count++;
+      GetThreadSpecificContext() = tc;
+      task();
+      GetThreadSpecificContext() = 0;
+    };
+    std::atomic<int> count = 0;
+    tf::Taskflow taskflow;
+    std::vector<int> range(UPPER);
+    std::vector<int>::iterator result;
+    std::iota(range.begin(), range.end(), 0);
+    taskflow.find_if_not(
+        begin(range), end(range), result, [&](int i)
+        { return i !=500 && GetThreadSpecificContext() == tc; },
+        tf::StaticPartitioner(1), task_wrapper);
+    executor.run(taskflow).wait();
+
+    REQUIRE(wrapper_called_count == tc);
+    REQUIRE(*result == 500);
+  }
+}


### PR DESCRIPTION
fixes #504 

This can be used for multiple purposes. For handling exceptions we could do

```cpp
tf::Executor executor(tc);
std::exception_ptr x;
auto task_wrapper = [&](auto &&task)
{
  try {
  task();
  }catch(...){
    x = std::current_exception();
  }
};
std::atomic<int> count = 0;
tf::Taskflow taskflow;
taskflow.for_each_index(
    0, 100, 1, [&](int i)
    { count++; },
    tf::StaticPartitioner(1), task_wrapper);
executor.run(taskflow).wait();
if(x)
   std::rethrow_exception(exceptionPtr);
```

Our use case is to apply captured floating point settings from parent tasks to sub tasks 

```
class FPUSaver;
class FPUApplier;
```

```cpp
tf::Executor executor(tc);
std::exception_ptr x;
/// Capture the floating point unit configuration
FPUSaver saver;
auto task_wrapper = [&](auto &&task)
{
  try {
    /// Apply the floating point unit configuration ( and undo on destruction
    FPUApplier applier(saver);
    task();
  }catch(...){
    x = std::current_exception();
  }
};
std::atomic<int> count = 0;
tf::Taskflow taskflow;
taskflow.for_each_index(
    0, 100, 1, [&](int i)
    { count++; },
    tf::StaticPartitioner(1), task_wrapper);
executor.run(taskflow).wait();
if(x)
   std::rethrow_exception(exceptionPtr);

```