### PR TITLE
Update tsq.hpp

### DIFF
--- a/taskflow/core/tsq.hpp
+++ b/taskflow/core/tsq.hpp
@@ -263,7 +263,7 @@ TaskQueue<T, TF_MAX_PRIORITY>::TaskQueue(int64_t c) {
   unroll<0, TF_MAX_PRIORITY, 1>([&](auto p){
     _top[p].data.store(0, std::memory_order_relaxed);
     _bottom[p].data.store(0, std::memory_order_relaxed);
-    _array[p].store(new Array{c}, std::memory_order_relaxed);
+    _array[p].store(std::make_unique<Array>(c), std::memory_order_relaxed);
     _garbage[p].reserve(32);
   });
 }


### PR DESCRIPTION
内存泄露问题，new的过程中如果发出内存溢出，导致异常报错，则无法顺利调用析构函数释放资源。