### PR TITLE
Semaphore refactor

### DIFF
--- a/taskflow/algorithm/semaphore_guard.hpp
+++ b/taskflow/algorithm/semaphore_guard.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "../core/graph.hpp"
+#include "../core/semaphore.hpp"
+
+/**
+@file semaphore.hpp
+@brief semaphore guard include file
+*/
+
+namespace tf {
+
+// ----------------------------------------------------------------------------
+// SemaphoreGuard
+// ----------------------------------------------------------------------------
+
+/**
+@class SemaphoreGuard
+
+@brief class to implement a RAII semaphore guard to help developer control
+tf::Semaphore ownership within a scope, releasing ownership in the
+destructor. It is recommended to use it to make sure lock is release in a
+properly order to avoid deadlocking.
+
+The usage of SemaphoreGuard is pretty like std::lock_guard's. One difference is
+that user should pass tf::Runtime reference as a parameter to tf::SemaphoreGuard
+due to the implementation need.
+
+@code{.cpp}
+tf::Semaphore se(1);
+tf::Executor executor(2);
+tf::Taskflow taskflow;
+int32_t count = 0;
+auto t1 = taskflow.emplace([&](tf::Runtime& rt) {
+                    tf::SemaphoreGuard gd(rt, se);
+                    --count;
+                  })
+auto t2 = taskflow.emplace([&](tf::Runtime& rt) {
+                    tf::SemaphoreGuard gd(rt, se);
+                    ++count;
+                  });
+executor.run(taskflow);
+executor.wait_for_all();
+@endcode
+
+*/
+class SemaphoreGuard {
+  public:
+  explicit SemaphoreGuard(tf::Runtime& rt, tf::Semaphore& se) :
+          _rt(rt), _se(se) {
+    _rt.acquire(_se);
+  }
+
+  ~SemaphoreGuard() {
+    _rt.release(_se);
+  }
+
+  SemaphoreGuard(const SemaphoreGuard&) = delete;
+  SemaphoreGuard& operator=(const SemaphoreGuard&) = delete;
+
+  private:
+  tf::Runtime& _rt;
+  tf::Semaphore& _se;
+};
+
+} // end of namespace tf. ---------------------------------------------------

--- a/taskflow/core/executor.hpp
+++ b/taskflow/core/executor.hpp
@@ -2376,6 +2376,20 @@ inline Runtime::~Runtime() {
   }
 }
 
+inline void Runtime::acquire(Semaphore& s) {
+  bool enque = false;
+  corun_until([&]() {
+    if (TF_UNLIKELY(!enque)) {
+      enque = true;
+      return s._try_acquire_or_wait<true>(this->_parent);
+    }
+    return s._try_acquire_or_wait<false>(this->_parent);
+  });
+}
+
+inline void Runtime::release(Semaphore& s) {
+  s._release(this->_parent);
+}
 }  // end of namespace tf -----------------------------------------------------
 
 

--- a/taskflow/core/graph.hpp
+++ b/taskflow/core/graph.hpp
@@ -442,6 +442,18 @@ class Runtime {
   */
   inline Worker& worker();
 
+  /**
+   @brief try to acquire a semaphore
+   * 
+   */
+  void acquire(Semaphore& s);
+
+  /**
+   @brief try to acquire a semaphore
+   * 
+   */
+  void release(Semaphore& s);
+
   protected:
   
   /**
@@ -894,7 +906,7 @@ inline bool Node::_acquire_all(SmallVector<Node*>& nodes) {
   auto& to_acquire = _semaphores->to_acquire;
 
   for(size_t i = 0; i < to_acquire.size(); ++i) {
-    if(!to_acquire[i]->_try_acquire_or_wait(this)) {
+    if(!to_acquire[i]->_try_acquire_or_wait<true>(this)) {
       for(size_t j = 1; j <= i; ++j) {
         auto r = to_acquire[i-j]->_release();
         nodes.insert(std::end(nodes), std::begin(r), std::end(r));

--- a/taskflow/core/semaphore.hpp
+++ b/taskflow/core/semaphore.hpp
@@ -70,6 +70,7 @@ class Semaphore {
 
   friend class Node;
   friend class Runtime;
+  friend class Executor;
 
   public:
 

--- a/taskflow/core/worker.hpp
+++ b/taskflow/core/worker.hpp
@@ -67,6 +67,16 @@ class Worker {
     std::default_random_engine _rdgen { std::random_device{}() };
     TaskQueue<Node*> _wsq;
     Node* _cache;
+
+  enum class SideProcessStatus : int {
+    UNASSIGNED = 0,
+    SEMAPHORE_SUCCESS = 1,
+    STEAL_SUCCESS = 2
+  };
+  std::mutex _predicate_mtx;
+  std::condition_variable _predicate_cv;
+  std::atomic<SideProcessStatus> _predicate_status;
+  Node* _stealed_task;
 };
 
 // ----------------------------------------------------------------------------

--- a/unittests/test_semaphores.cpp
+++ b/unittests/test_semaphores.cpp
@@ -317,14 +317,21 @@ void bench_semaphore(size_t W, size_t N) {
     t.acquire(se_2).release(se_2);
   }
 
+  // some independent workload
+  for (size_t i = 0; i < N; i++) {
+    taskflow.emplace([&]() {
+      std::this_thread::sleep_for(std::chrono::microseconds(10));
+    });
+  }
+
   auto beg = std::chrono::high_resolution_clock::now();
   executor.run(taskflow).wait();
   auto end = std::chrono::high_resolution_clock::now();
-  // std::cout << "semaphore worker_num:" << W << " thread_num:" << N
-  //           << " time cost : "
-  //           << std::chrono::duration_cast<std::chrono::microseconds>(end - beg)
-  //                      .count()
-  //           << "us." << std::endl;
+  std::cout << "semaphore worker_num:" << W << " thread_num:" << N
+            << " time cost : "
+            << std::chrono::duration_cast<std::chrono::microseconds>(end - beg)
+                       .count()
+            << "us." << std::endl;
 }
 
 void bench_intask_semaphore(size_t W, size_t N) {
@@ -352,14 +359,21 @@ void bench_intask_semaphore(size_t W, size_t N) {
     });
   }
 
+  // some independent workload
+  for (size_t i = 0; i < N; i++) {
+    taskflow.emplace([&]() {
+      std::this_thread::sleep_for(std::chrono::microseconds(10));
+    });
+  }
+
   auto beg = std::chrono::high_resolution_clock::now();
   executor.run(taskflow).wait();
   auto end = std::chrono::high_resolution_clock::now();
-  // std::cout << "intask_semaphore worker_num:" << W << " thread_num:" << N
-  //           << " time cost : "
-  //           << std::chrono::duration_cast<std::chrono::microseconds>(end - beg)
-  //                      .count()
-  //           << "us." << std::endl;
+  std::cout << "intask_semaphore worker_num:" << W << " thread_num:" << N
+            << " time cost : "
+            << std::chrono::duration_cast<std::chrono::microseconds>(end - beg)
+                       .count()
+            << "us." << std::endl;
 }
 
 #define TASKFLOW_TEST_SEMAPHORE_BENCHMARK(W, N)                                \
@@ -368,16 +382,16 @@ void bench_intask_semaphore(size_t W, size_t N) {
     bench_intask_semaphore(W, N);                                              \
   }
 
-TASKFLOW_TEST_SEMAPHORE_BENCHMARK(1, 10000);
-TASKFLOW_TEST_SEMAPHORE_BENCHMARK(2, 10000);
-TASKFLOW_TEST_SEMAPHORE_BENCHMARK(4, 10000);
-TASKFLOW_TEST_SEMAPHORE_BENCHMARK(8, 10000);
-TASKFLOW_TEST_SEMAPHORE_BENCHMARK(16, 10000);
+TASKFLOW_TEST_SEMAPHORE_BENCHMARK(1, 100);
+TASKFLOW_TEST_SEMAPHORE_BENCHMARK(2, 100);
+TASKFLOW_TEST_SEMAPHORE_BENCHMARK(4, 100);
+TASKFLOW_TEST_SEMAPHORE_BENCHMARK(8, 100);
+TASKFLOW_TEST_SEMAPHORE_BENCHMARK(16, 100);
 
-TASKFLOW_TEST_SEMAPHORE_BENCHMARK(1, 20000);
-TASKFLOW_TEST_SEMAPHORE_BENCHMARK(2, 20000);
-TASKFLOW_TEST_SEMAPHORE_BENCHMARK(4, 20000);
-TASKFLOW_TEST_SEMAPHORE_BENCHMARK(8, 20000);
-TASKFLOW_TEST_SEMAPHORE_BENCHMARK(16, 20000);
+TASKFLOW_TEST_SEMAPHORE_BENCHMARK(1, 200);
+TASKFLOW_TEST_SEMAPHORE_BENCHMARK(2, 200);
+TASKFLOW_TEST_SEMAPHORE_BENCHMARK(4, 200);
+TASKFLOW_TEST_SEMAPHORE_BENCHMARK(8, 200);
+TASKFLOW_TEST_SEMAPHORE_BENCHMARK(16, 200);
 
 #undef TASKFLOW_TEST_SEMAPHORE_BENCHMARK

--- a/unittests/test_semaphores.cpp
+++ b/unittests/test_semaphores.cpp
@@ -1,7 +1,10 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 
+#include <chrono>
+
 #include <doctest.h>
 #include <taskflow/taskflow.hpp>
+#include <taskflow/algorithm/semaphore_guard.hpp>
 
 // --------------------------------------------------------
 // Testcase: CriticalSection
@@ -209,3 +212,172 @@ TEST_CASE("ConflictGraph.3threads") {
 TEST_CASE("ConflictGraph.4threads") {
   conflict_graph(4);
 }
+
+// --------------------------------------------------------
+// Testcase: In-task Semaphore
+// --------------------------------------------------------
+
+TEST_CASE("IntaskSemaphore.Happypass") {
+  tf::Semaphore se(1);
+  tf::Executor executor(2);
+  tf::Taskflow taskflow;
+  int32_t count = 0;
+  taskflow.emplace([&](tf::Runtime& rt) {
+            rt.acquire(se);
+            --count;
+            rt.release(se);
+          })
+          .priority(tf::TaskPriority::LOW);
+  taskflow.emplace([&](tf::Runtime& rt) {
+            rt.acquire(se);
+            ++count;
+            rt.release(se);
+          })
+          .priority(tf::TaskPriority::HIGH);
+  executor.run(taskflow);
+  executor.wait_for_all();
+  REQUIRE(count == 0);
+}
+
+void intask_semaphore(size_t W) {
+  tf::Executor executor(W);
+  tf::Taskflow taskflow;
+  tf::Semaphore se(1);
+
+  int N = 1000;
+  int counter = 0;
+
+  for (int i = 0; i < N; i++) {
+    auto f = taskflow.emplace([&](tf::Runtime& rt) {
+      rt.acquire(se);
+      counter++;
+    });
+    auto t = taskflow.emplace([&](tf::Runtime& rt) {
+      counter++;
+      rt.release(se);
+    });
+    f.precede(t);
+  }
+
+  executor.run(taskflow).wait();
+
+  REQUIRE(counter == 2 * N);
+}
+
+TEST_CASE("IntaskSemaphore.1thread") {
+  intask_semaphore(1);
+}
+
+TEST_CASE("IntaskSemaphore.2threads") {
+  intask_semaphore(2);
+}
+
+TEST_CASE("IntaskSemaphore.3threads") {
+  intask_semaphore(3);
+}
+
+TEST_CASE("IntaskSemaphore.4threads") {
+  intask_semaphore(4);
+}
+
+TEST_CASE("IntaskSemaphore.SemaphoreGuard") {
+  tf::Semaphore se(1);
+  tf::Executor executor(2);
+  tf::Taskflow taskflow;
+  int32_t count = 0;
+  taskflow.emplace([&](tf::Runtime& rt) {
+            tf::SemaphoreGuard gd(rt, se);
+            --count;
+          })
+          .priority(tf::TaskPriority::LOW);
+  taskflow.emplace([&](tf::Runtime& rt) {
+            tf::SemaphoreGuard gd(rt, se);
+            ++count;
+          })
+          .priority(tf::TaskPriority::HIGH);
+  executor.run(taskflow);
+  executor.wait_for_all();
+  REQUIRE(count == 0);
+}
+
+void bench_semaphore(size_t W, size_t N) {
+  tf::Executor executor(W);
+  tf::Taskflow taskflow;
+  tf::Semaphore se_1(1);
+  tf::Semaphore se_2(1);
+
+  int counter = 0;
+
+  for (size_t i = 0; i < N; i++) {
+    auto f = taskflow.emplace([&]() { counter++; });
+    auto t = taskflow.emplace([&]() { counter++; });
+    f.acquire(se_1).release(se_1);
+    t.acquire(se_1).release(se_1);
+    f.acquire(se_2).release(se_2);
+    t.acquire(se_2).release(se_2);
+  }
+
+  auto beg = std::chrono::high_resolution_clock::now();
+  executor.run(taskflow).wait();
+  auto end = std::chrono::high_resolution_clock::now();
+  // std::cout << "semaphore worker_num:" << W << " thread_num:" << N
+  //           << " time cost : "
+  //           << std::chrono::duration_cast<std::chrono::microseconds>(end - beg)
+  //                      .count()
+  //           << "us." << std::endl;
+}
+
+void bench_intask_semaphore(size_t W, size_t N) {
+  tf::Executor executor(W);
+  tf::Taskflow taskflow;
+  tf::Semaphore se_1(1);
+  tf::Semaphore se_2(1);
+
+  int counter = 0;
+
+  for (size_t i = 0; i < N; i++) {
+    taskflow.emplace([&](tf::Runtime& rt) {
+      rt.acquire(se_1);
+      rt.acquire(se_2);
+      counter++;
+      rt.release(se_2);
+      rt.release(se_1);
+    });
+    taskflow.emplace([&](tf::Runtime& rt) {
+      rt.acquire(se_1);
+      rt.acquire(se_2);
+      counter++;
+      rt.release(se_2);
+      rt.release(se_1);
+    });
+  }
+
+  auto beg = std::chrono::high_resolution_clock::now();
+  executor.run(taskflow).wait();
+  auto end = std::chrono::high_resolution_clock::now();
+  // std::cout << "intask_semaphore worker_num:" << W << " thread_num:" << N
+  //           << " time cost : "
+  //           << std::chrono::duration_cast<std::chrono::microseconds>(end - beg)
+  //                      .count()
+  //           << "us." << std::endl;
+}
+
+#define TASKFLOW_TEST_SEMAPHORE_BENCHMARK(W, N)                                \
+  TEST_CASE("IntaskSemaphore.BenchmarkW##vN##") {                              \
+    bench_semaphore(W, N);                                                     \
+    bench_intask_semaphore(W, N);                                              \
+  }
+
+TASKFLOW_TEST_SEMAPHORE_BENCHMARK(1, 10000);
+TASKFLOW_TEST_SEMAPHORE_BENCHMARK(2, 10000);
+TASKFLOW_TEST_SEMAPHORE_BENCHMARK(4, 10000);
+TASKFLOW_TEST_SEMAPHORE_BENCHMARK(8, 10000);
+TASKFLOW_TEST_SEMAPHORE_BENCHMARK(16, 10000);
+
+TASKFLOW_TEST_SEMAPHORE_BENCHMARK(1, 20000);
+TASKFLOW_TEST_SEMAPHORE_BENCHMARK(2, 20000);
+TASKFLOW_TEST_SEMAPHORE_BENCHMARK(4, 20000);
+TASKFLOW_TEST_SEMAPHORE_BENCHMARK(8, 20000);
+TASKFLOW_TEST_SEMAPHORE_BENCHMARK(16, 20000);
+
+#undef TASKFLOW_TEST_SEMAPHORE_BENCHMARK


### PR DESCRIPTION
Please review this pr about a new implementation of tf::Semapohre and its RAII manage method tf::SemapohreGuard. I kept the original implementation of tf::Semaphore for compatibility and some-cases' performance.