### PR TITLE
add compiler explorer link with simple.cpp on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The following program (`simple.cpp`) creates four tasks
 `A`, `B`, `C`, and `D`, where `A` runs before `B` and `C`, and `D`
 runs after `B` and `C`.
 When `A` finishes, `B` and `C` can run in parallel.
+Try it live on [Compiler Explorer (godbolt)](https://godbolt.org/z/j8hx3xnnx)!
 
 
 


### PR DESCRIPTION
This PR adds a compiler explorer link on README with simple.cpp example. This can 
- easily onboard more users without any local environments
- enables both developers and users to perform live demo and quick verification
- reduces communication overhead among different local setups
- and more...