### PR TITLE
C++-20 compilation error fix

### DIFF
--- a/taskflow/cuda/cuda_memory.hpp
+++ b/taskflow/cuda/cuda_memory.hpp
@@ -498,7 +498,7 @@ class cudaDeviceAllocator {
   @param n number of elements (each of size sizeof(value_type)) to be allocated
   @return a pointer to the initial element in the block of storage.
   */
-  pointer allocate( size_type n, std::allocator<void>::const_pointer = 0 )
+  pointer allocate( size_type n, void const* = 0 )
   {
     void* ptr = NULL;
     TF_CHECK_CUDA(
@@ -694,7 +694,7 @@ class cudaUSMAllocator {
   @param n number of elements (each of size sizeof(value_type)) to be allocated
   @return a pointer to the initial element in the block of storage.
   */
-  pointer allocate( size_type n, std::allocator<void>::const_pointer = 0 )
+  pointer allocate( size_type n, void const* = 0 )
   {
     void* ptr {nullptr};
     TF_CHECK_CUDA(

--- a/taskflow/cuda/cuda_memory.hpp
+++ b/taskflow/cuda/cuda_memory.hpp
@@ -498,7 +498,7 @@ class cudaDeviceAllocator {
   @param n number of elements (each of size sizeof(value_type)) to be allocated
   @return a pointer to the initial element in the block of storage.
   */
-  pointer allocate( size_type n, void const* = 0 )
+  pointer allocate( size_type n, const void* = 0 )
   {
     void* ptr = NULL;
     TF_CHECK_CUDA(
@@ -694,7 +694,7 @@ class cudaUSMAllocator {
   @param n number of elements (each of size sizeof(value_type)) to be allocated
   @return a pointer to the initial element in the block of storage.
   */
-  pointer allocate( size_type n, void const* = 0 )
+  pointer allocate( size_type n, const void* = 0 )
   {
     void* ptr {nullptr};
     TF_CHECK_CUDA(


### PR DESCRIPTION
C++ 20 has removed the std::allocator<void>-specialisation, quick wokaround is to replace the type alias with the intended type. Fixes issue 539.