### PR TITLE
PoC: For Each (Range) Index 

### DIFF
--- a/taskflow/algorithm/for_each.hpp
+++ b/taskflow/algorithm/for_each.hpp
@@ -84,16 +84,16 @@ using is_range_func = std::is_invocable_r<void, C, T, T>;
 // Function: make_for_each_index_task
 template <typename T, typename C, typename P = DefaultPartitioner>
 TF_FORCE_INLINE auto make_for_each_index_task(T b, T e, C c, P part = P()){
-  static_assert(std::is_integral<T>::value, "Begin and end values must be an integral type.");
+  using T_t = std::decay_t<unwrap_ref_decay_t<T>>;
+
+  static_assert(std::is_integral<T_t>::value, "Begin and end values must be an integral type.");
   static_assert(
-        std::disjunction<is_index_func<T, C>, is_range_func<T, C>>::value,
+        std::disjunction<is_index_func<T_t, C>, is_range_func<T_t, C>>::value,
         "C must be either a void function taking one int or two ints"
   );
   constexpr bool is_index_callable = is_index_func<T, C>::value;
 
   using namespace std::string_literals;
-
-  using T_t = std::decay_t<unwrap_ref_decay_t<T>>;
 
   return [=] (Runtime& rt) mutable {
 
@@ -107,17 +107,18 @@ TF_FORCE_INLINE auto make_for_each_index_task(T b, T e, C c, P part = P()){
     }
 
     size_t W = rt.executor().num_workers();
-    size_t N = end-beg;
+    T_t n = end-beg;
+    size_t N = static_cast<size_t>(n);
 
     // only myself - no need to spawn another graph
     if(W <= 1 || N <= part.chunk_size()) {
       TF_MAKE_LOOP_TASK(
         if constexpr(is_index_callable) {
-          for(T_t i=0; i<N; i++) {
+          for(T_t i=0; i<n; i++) {
             c(i);
           }
         } else {
-          c(0, N);
+          c(0, n);
         }
       );
       return;
@@ -138,10 +139,10 @@ TF_FORCE_INLINE auto make_for_each_index_task(T b, T e, C c, P part = P()){
               [&](size_t part_b, size_t part_e) {
                 if constexpr(is_index_callable) {
                   for(size_t i=part_b; i<part_e; i++) {
-                    c(i);
+                    c(static_cast<T_t>(i));
                   }
                 } else {
-                  c(part_b, part_e);
+                  c(static_cast<T_t>(part_b), static_cast<T_t>(part_e));
                 }
               }
             ); 
@@ -160,10 +161,10 @@ TF_FORCE_INLINE auto make_for_each_index_task(T b, T e, C c, P part = P()){
             [&](size_t part_b, size_t part_e) {
               if constexpr(is_index_callable) {
                 for(size_t i=part_b; i<part_e; i++) {
-                  c(i);
+                  c(static_cast<T_t>(i));
                 }
               } else {
-                c(part_b, part_e);
+                c(static_cast<T_t>(part_b), static_cast<T_t>(part_e));
               }
             }
           ); 

--- a/taskflow/core/flow_builder.hpp
+++ b/taskflow/core/flow_builder.hpp
@@ -355,44 +355,30 @@ class FlowBuilder {
   /**
   @brief constructs an STL-styled index-based parallel-for task 
 
-  @tparam B beginning index type (must be integral)
-  @tparam E ending index type (must be integral)
-  @tparam S step type (must be integral)
+  @tparam T beginning index type (must be integral)
+  @tparam T ending index type (must be integral)
   @tparam C callable type
   @tparam P partitioner type (default tf::DefaultPartitioner)
 
   @param first index of the beginning (inclusive)
   @param last index of the end (exclusive)
-  @param step step size
   @param callable callable object to apply to each valid index
   @param part partitioning algorithm to schedule parallel iterations
 
   @return a tf::Task handle
 
   The task spawns asynchronous tasks that applies the callable object to each index
-  in the range <tt>[first, last)</tt> with the step size.
+  in the range <tt>[first, last)</tt>.
   This method is equivalent to the parallel execution of the following loop:
-
-  @code{.cpp}
-  // case 1: step size is positive
-  for(auto i=first; i<last; i+=step) {
-    callable(i);
-  }
-
-  // case 2: step size is negative
-  for(auto i=first, i>last; i+=step) {
-    callable(i);
-  }
-  @endcode
 
   Iterators are templated to enable stateful range using std::reference_wrapper.
   The callable needs to take a single argument of the integral index type.
 
   Please refer to @ref ParallelIterations for details.
   */
-  template <typename B, typename E, typename S, typename C, typename P = DefaultPartitioner>
+  template <typename T, typename C, typename P = DefaultPartitioner>
   Task for_each_index(
-    B first, E last, S step, C callable, P part = P()
+    T first, T last, C callable, P part = P()
   );
 
   // ------------------------------------------------------------------------
@@ -1408,13 +1394,3 @@ inline void Subflow::reset(bool clear_graph) {
 }
 
 }  // end of namespace tf. ---------------------------------------------------
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Proof of concept for feature proposed in https://github.com/taskflow/taskflow/issues/551

A few notes: 

- I firmly believe that increment should not be part of the API and the called function should have the responsibility to handle any sort of increment. The fact that TBB doesn't have an increment argument supports my point. 
- I don't understand why begin, end (and the removed step) are implemented as different template arguments ? They should be the same integral types ? Am I missing something ?
- This is a PoC so the code is not intended to be merged as is. 

Minimal example code of the new functionality:

```
#include <taskflow/taskflow.hpp>
#include <taskflow/algorithm/for_each.hpp>

#include <iostream>
#include <mutex>

int main() {
    tf::Executor executor;
    tf::Taskflow taskflow;
    std::mutex mutex;

    auto init = taskflow.placeholder();
    auto body_index = taskflow.for_each_index(0, 10, [&](int i) {
        std::scoped_lock lock(mutex);
        std::cout << "Hello from task " << i << std::endl;
    });

    auto body_range = taskflow.for_each_index(0, 1000, [&](int b, int e) {
        std::scoped_lock lock(mutex);
        std::cout << "Hello from task range [" << b << ", " << e << ")" << std::endl;
    });

    init.precede(body_index);
    body_index.precede(body_range);

    executor.run(taskflow).wait();
    
    return 0;
}
```