### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ MESSAGE(STATUS "CMAKE_ROOT: " ${CMAKE_ROOT})
 # Project name
 project(Taskflow VERSION 3.7.0 LANGUAGES CXX)
 
+set(CMAKE_CXX_STANDARD 17)
+
 # build options
 option(TF_BUILD_BENCHMARKS "Enables builds of benchmarks" OFF)
 option(TF_BUILD_CUDA "Enables builds of cuda code" OFF)
@@ -48,9 +50,9 @@ include(GNUInstallDirs)
 # Compiler vendors
 ## g++
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "7.0")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "8.4")
     message(STATUS "CMAKE_CXX_COMPILER_VERSION: ${CMAKE_CXX_COMPILER_VERSION}")
-    message(FATAL_ERROR "\nTaskflow requires g++ at least v7.0")
+    message(FATAL_ERROR "\nTaskflow requires g++ at least v8.4")
   endif()
 ## clang++
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
@@ -60,8 +62,8 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   endif() 
 ## AppleClang
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "8.0")
-    message(FATAL_ERROR "\nTaskflow requires AppleClang at least v8.0")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "12.0")
+    message(FATAL_ERROR "\nTaskflow requires AppleClang at least v12.0")
   endif()
 ## microsoft visual c++
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")


### PR DESCRIPTION
Set default CXX Standard to C++17 as it is the minimum required.

User can override it for experimentation.

Update the minimum required compiler support for GNU/GCC and AppleClang per documentation.

Addresses: https://github.com/taskflow/taskflow/issues/566