### PR TITLE
Handle the need to explicitly link to libatomic on some archs (#578)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,9 @@ include(CheckLanguage)
 # Adhere to GNU conventions
 include(GNUInstallDirs)
 
+# Check for correct settings for atomic library
+include(${CMAKE_SOURCE_DIR}/cmake/CheckAtomic.cmake)
+
 # Compiler vendors
 ## g++
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
@@ -300,7 +303,7 @@ find_package(Threads REQUIRED)
 
 add_library(${PROJECT_NAME} INTERFACE)
 target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_17)
-target_link_libraries(${PROJECT_NAME} INTERFACE Threads::Threads)
+target_link_libraries(${PROJECT_NAME} INTERFACE ${ATOMIC_LIBRARY} Threads::Threads)
 target_include_directories(${PROJECT_NAME} INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:include/> 

--- a/LICENSE
+++ b/LICENSE
@@ -21,3 +21,46 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---------------------------------
+The file cmake/CheckAtomic.cmake has the following license conditions.
+
+University of Illinois/NCSA Open Source License
+
+Copyright (c) 2003-2018 University of Illinois at Urbana-Champaign. All rights
+reserved.
+
+Developed by:
+
+LLVM Team
+
+University of Illinois at Urbana-Champaign
+
+http://llvm.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+with the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimers.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimers in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the names of the LLVM Team, University of Illinois at
+  Urbana-Champaign, nor the names of its contributors may be used to endorse
+  or promote products derived from this Software without specific prior
+  written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH
+THE SOFTWARE.

--- a/cmake/CheckAtomic.cmake
+++ b/cmake/CheckAtomic.cmake
@@ -1,0 +1,157 @@
+# ==============================================================================
+# LLVM Release License
+# ==============================================================================
+# University of Illinois/NCSA Open Source License
+#
+# Copyright (c) 2003-2018 University of Illinois at Urbana-Champaign. All rights
+# reserved.
+#
+# Developed by:
+#
+# LLVM Team
+#
+# University of Illinois at Urbana-Champaign
+#
+# http://llvm.org
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# with the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimers.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimers in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the names of the LLVM Team, University of Illinois at
+#   Urbana-Champaign, nor the names of its contributors may be used to endorse
+#   or promote products derived from this Software without specific prior
+#   written permission.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH
+# THE SOFTWARE.
+
+include(CheckCXXSourceCompiles)
+include(CheckLibraryExists)
+
+# Sometimes linking against libatomic is required for atomic ops, if the
+# platform doesn't support lock-free atomics.
+
+function(check_working_cxx_atomics varname)
+  set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+  set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -std=c++11")
+  check_cxx_source_compiles(
+    "
+#include <atomic>
+std::atomic<long long> x;
+int main() {
+  return std::atomic_is_lock_free(&x);
+}
+"
+    ${varname})
+  set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
+endfunction(check_working_cxx_atomics)
+
+function(check_working_cxx_atomics64 varname)
+  set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+  set(CMAKE_REQUIRED_FLAGS "-std=c++11 ${CMAKE_REQUIRED_FLAGS}")
+  check_cxx_source_compiles(
+    "
+#include <atomic>
+#include <cstdint>
+std::atomic<uint64_t> x (0);
+int main() {
+  uint64_t i = x.load(std::memory_order_relaxed);
+  return std::atomic_is_lock_free(&x);
+}
+"
+    ${varname})
+  set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
+endfunction(check_working_cxx_atomics64)
+
+function(check_working_cxx_atomics_2args varname)
+  set(OLD_CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES})
+  list(APPEND CMAKE_REQUIRED_LIBRARIES "atomic")
+  check_cxx_source_compiles(
+    "
+int main() {
+  __atomic_load(nullptr, 0);
+  return 0;
+}
+"
+    ${varname})
+  set(CMAKE_REQUIRED_LIBRARIES ${OLD_CMAKE_REQUIRED_LIBRARIES})
+endfunction(check_working_cxx_atomics_2args)
+
+function(check_working_cxx_atomics64_2args varname)
+  set(OLD_CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES})
+  list(APPEND CMAKE_REQUIRED_LIBRARIES "atomic")
+  check_cxx_source_compiles(
+    "
+int main() {
+  __atomic_load_8(nullptr, 0);
+  return 0;
+}
+"
+    ${varname})
+  set(CMAKE_REQUIRED_LIBRARIES ${OLD_CMAKE_REQUIRED_LIBRARIES})
+endfunction(check_working_cxx_atomics64_2args)
+
+# First check if atomics work without the library.
+check_working_cxx_atomics(HAVE_CXX_ATOMICS_WITHOUT_LIB)
+
+set(ATOMIC_LIBRARY "")
+
+# If not, check if the library exists, and atomics work with it.
+if(NOT HAVE_CXX_ATOMICS_WITHOUT_LIB)
+  check_library_exists(atomic __atomic_fetch_add_4 "" HAVE_LIBATOMIC)
+  if(NOT HAVE_LIBATOMIC)
+    check_working_cxx_atomics_2args(HAVE_LIBATOMIC_2ARGS)
+  endif()
+  if(HAVE_LIBATOMIC OR HAVE_LIBATOMIC_2ARGS)
+    list(APPEND CMAKE_REQUIRED_LIBRARIES "atomic")
+    set(ATOMIC_LIBRARY "atomic")
+    check_working_cxx_atomics(HAVE_CXX_ATOMICS_WITH_LIB)
+    if(NOT HAVE_CXX_ATOMICS_WITH_LIB)
+      message(FATAL_ERROR "Host compiler must support std::atomic!")
+    endif()
+  else()
+    # Check for 64 bit atomic operations.
+    if(MSVC)
+      set(HAVE_CXX_ATOMICS64_WITHOUT_LIB True)
+    else()
+      check_working_cxx_atomics64(HAVE_CXX_ATOMICS64_WITHOUT_LIB)
+    endif()
+
+    # If not, check if the library exists, and atomics work with it.
+    if(NOT HAVE_CXX_ATOMICS64_WITHOUT_LIB)
+      check_library_exists(atomic __atomic_load_8 "" HAVE_CXX_LIBATOMICS64)
+      if(NOT HAVE_CXX_LIBATOMICS64)
+        check_working_cxx_atomics64_2args(HAVE_CXX_LIBATOMICS64_2ARGS)
+      endif()
+      if(HAVE_CXX_LIBATOMICS64 OR HAVE_CXX_LIBATOMICS64_2ARGS)
+        list(APPEND CMAKE_REQUIRED_LIBRARIES "atomic")
+        set(ATOMIC_LIBRARY "atomic")
+        check_working_cxx_atomics64(HAVE_CXX_ATOMICS64_WITH_LIB)
+        if(NOT HAVE_CXX_ATOMICS64_WITH_LIB)
+          message(FATAL_ERROR "Host compiler must support std::atomic!")
+        endif()
+      else()
+        message(
+          FATAL_ERROR
+            "Host compiler appears to require libatomic, but cannot find it.")
+      endif()
+    endif()
+
+  endif()
+endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -42,7 +42,7 @@ list(APPEND TF_EXAMPLES
 foreach(example IN LISTS TF_EXAMPLES)
   add_executable(${example} ${example}.cpp)
   target_link_libraries(
-    ${example} ${PROJECT_NAME} tf::default_settings
+    ${example} ${PROJECT_NAME} ${ATOMIC_LIBRARY} tf::default_settings
     )
   # set emcc options
   if (CMAKE_SYSTEM_NAME STREQUAL Emscripten)

--- a/examples/cuda/CMakeLists.txt
+++ b/examples/cuda/CMakeLists.txt
@@ -20,7 +20,7 @@ list(APPEND TF_CUDA_EXAMPLES
 foreach(cuda_example IN LISTS TF_CUDA_EXAMPLES)
   add_executable(${cuda_example} ${cuda_example}.cu)
   target_link_libraries(${cuda_example}
-    ${PROJECT_NAME} Threads::Threads tf::default_settings
+    ${PROJECT_NAME} ${ATOMIC_LIBRARY} Threads::Threads tf::default_settings
   )
 
   # avoid cmake 3.18+ warning

--- a/examples/sycl/CMakeLists.txt
+++ b/examples/sycl/CMakeLists.txt
@@ -16,6 +16,6 @@ foreach(sycl_example IN LISTS TF_SYCL_EXAMPLES)
   target_compile_options(${sycl_example} PRIVATE ${TF_SYCL_OPTIONS})
   target_link_options(${sycl_example} PRIVATE ${TF_SYCL_OPTIONS})
   target_link_libraries(${sycl_example}
-    ${PROJECT_NAME} Threads::Threads tf::default_settings
+    ${PROJECT_NAME} ${ATOMIC_LIBRARY} Threads::Threads tf::default_settings
   )
 endforeach()

--- a/tfprof/server/CMakeLists.txt
+++ b/tfprof/server/CMakeLists.txt
@@ -2,7 +2,7 @@
 add_executable(tfprof tfprof.cpp)
 
 target_link_libraries(
-  tfprof ${PROJECT_NAME} tf::default_settings
+  tfprof ${PROJECT_NAME} ${ATOMIC_LIBRARY} tf::default_settings
 )
 
 target_include_directories(tfprof PRIVATE ${TF_3RD_PARTY_DIR})

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 
 foreach(unittest IN LISTS TF_UNITTESTS)
   add_executable(${unittest} ${unittest}.cpp)
-  target_link_libraries(${unittest} ${PROJECT_NAME} tf::default_settings)
+  target_link_libraries(${unittest} ${PROJECT_NAME} ${ATOMIC_LIBRARY} tf::default_settings)
   target_include_directories(${unittest} PRIVATE ${TF_3RD_PARTY_DIR}/doctest)
   doctest_discover_tests(${unittest})
 endforeach()

--- a/unittests/cuda/CMakeLists.txt
+++ b/unittests/cuda/CMakeLists.txt
@@ -23,7 +23,7 @@ list(APPEND TF_CUDA_UNITTESTS
 
 foreach(cudatest IN LISTS TF_CUDA_UNITTESTS)
   add_executable(${cudatest} ${cudatest}.cu)
-  target_link_libraries(${cudatest} ${PROJECT_NAME} tf::default_settings)
+  target_link_libraries(${cudatest} ${PROJECT_NAME} ${ATOMIC_LIBRARY} tf::default_settings)
   target_include_directories(${cudatest} PRIVATE ${TF_3RD_PARTY_DIR}/doctest)
   
   # avoid cmake 3.18+ warning

--- a/unittests/sycl/CMakeLists.txt
+++ b/unittests/sycl/CMakeLists.txt
@@ -12,7 +12,7 @@ foreach(sycl_test IN LISTS TF_SYCL_TESTS)
   target_compile_options(${sycl_test} PRIVATE ${TF_SYCL_OPTIONS})
   target_link_options(${sycl_test} PRIVATE ${TF_SYCL_OPTIONS})
   target_link_libraries(${sycl_test}
-    ${PROJECT_NAME} Threads::Threads tf::default_settings
+    ${PROJECT_NAME} ${ATOMIC_LIBRARY} Threads::Threads tf::default_settings
   )
   target_include_directories(${sycl_test} PRIVATE ${TF_3RD_PARTY_DIR}/doctest)
   


### PR DESCRIPTION
This patch appears to fix the undefined reference to `__atomic_*_8` issue (#578).  I might have specified `${ATOMIC_LIBRARY}` more than needed, but everything seems to compile with this patch (at least when applied to v3.6.0 rather than HEAD) both on an amd64 machine and on an armel machine.