### PR TITLE
operator new() will never return a 'nullptr'.

### DIFF
--- a/taskflow/utility/object_pool.hpp
+++ b/taskflow/utility/object_pool.hpp
@@ -625,10 +625,6 @@ T* ObjectPool<T, S>::animate(ArgsT&&... args) {
       //s = static_cast<Block*>(std::malloc(sizeof(Block)));
       s = new Block();
 
-      if(s == nullptr) {
-        throw std::bad_alloc();
-      }
-
       s->heap = &h;
       s->i = 0;
       s->u = 0;


### PR DESCRIPTION
`operator new` will throw `std::bad_alloc` if it cannot allocate enough space. It is not necessary to check the returned value against `nullptr`.