### PR TITLE
Doxygen fix for Executor class

### DIFF
--- a/doxygen/Doxyfile
+++ b/doxygen/Doxyfile
@@ -545,7 +545,7 @@ NUM_PROC_THREADS       = 1
 # normally produced when WARNINGS is set to YES.
 # The default value is: NO.
 
-EXTRACT_ALL            = NO
+EXTRACT_ALL            = YES
 
 # If the EXTRACT_PRIVATE tag is set to YES, all private members of a class will
 # be included in the documentation.
@@ -2412,7 +2412,7 @@ PERLMOD_MAKEVAR_PREFIX =
 # C-preprocessor directives found in the sources and include files.
 # The default value is: YES.
 
-ENABLE_PREPROCESSING   = NO
+ENABLE_PREPROCESSING   = YES
 
 # If the MACRO_EXPANSION tag is set to YES, doxygen will expand all macro names
 # in the source code. If set to NO, only conditional compilation will be
@@ -2462,7 +2462,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = DOXYGEN=1
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/taskflow/core/executor.hpp
+++ b/taskflow/core/executor.hpp
@@ -1102,6 +1102,9 @@ class Executor {
 
 };
 
+
+#ifndef DOXYGEN
+
 // Constructor
 inline Executor::Executor(size_t N) :
   _MAX_STEALS {((N+1) << 1)},
@@ -2431,7 +2434,7 @@ auto Runtime::async(P&& params, F&& f) {
 
 
 
-
+#endif
 
 
 }  // end of namespace tf -----------------------------------------------------


### PR DESCRIPTION
The current doxygen documentation does not show the class ``Executor``, see https://taskflow.github.io/taskflow/annotated.html. I don't know for sure which line of code inside the executor.hpp file confuses doxygen, but excluding the implementations from being parsed by doxygen fixes the issue. For this, I had to let doxygen define a DOXYGEN macro.