### PR TITLE
Make `for_each_index` actually heterogeneous

### DIFF
--- a/taskflow/utility/iterator.hpp
+++ b/taskflow/utility/iterator.hpp
@@ -5,17 +5,21 @@
 
 namespace tf {
 
-template <typename T>
-constexpr std::enable_if_t<std::is_integral<std::decay_t<T>>::value, bool>
-is_range_invalid(T beg, T end, T step) {
+template <typename B, typename E, typename S>
+constexpr std::enable_if_t<std::is_integral<std::decay_t<B>>::value && 
+                           std::is_integral<std::decay_t<E>>::value && 
+                           std::is_integral<std::decay_t<S>>::value, bool>
+is_range_invalid(B beg, E end, S step) {
   return ((step == 0 && beg != end) ||
           (beg < end && step <=  0) ||  // positive range
           (beg > end && step >=  0));   // negative range
 }
 
-template <typename T>
-constexpr std::enable_if_t<std::is_integral<std::decay_t<T>>::value, size_t>
-distance(T beg, T end, T step) {
+template <typename B, typename E, typename S>
+constexpr std::enable_if_t<std::is_integral<std::decay_t<B>>::value && 
+                           std::is_integral<std::decay_t<E>>::value && 
+                           std::is_integral<std::decay_t<S>>::value, size_t>
+distance(B beg, E end, S step) {
   return (end - beg + step + (step > 0 ? -1 : 1)) / step;
 }
 

--- a/unittests/test_for_each.cpp
+++ b/unittests/test_for_each.cpp
@@ -609,7 +609,7 @@ TEST_CASE("ForEachIndex.HeterogeneousRange" * doctest::timeout(300)) {
 		counter.fetch_add(i, std::memory_order_relaxed);
 	});
 	ex.run(flow).wait();
-	REQUIRE(counter == to * (to + 1) / 2);
+	REQUIRE(counter == to * (to - 1) / 2);
 }
 
 // ----------------------------------------------------------------------------

--- a/unittests/test_for_each.cpp
+++ b/unittests/test_for_each.cpp
@@ -3,6 +3,7 @@
 #include <doctest.h>
 #include <taskflow/taskflow.hpp>
 #include <taskflow/algorithm/for_each.hpp>
+#include <cstdint>
 
 // --------------------------------------------------------
 // Testcase: for_each
@@ -589,6 +590,26 @@ TEST_CASE("ForEachIndex.InvalidRange" * doctest::timeout(300)) {
 	});
 	ex.run(flow).wait();
   REQUIRE(counter == 0);
+}
+
+// ----------------------------------------------------------------------------
+// ForEachIndex.HeterogeneousRange
+// ----------------------------------------------------------------------------
+
+TEST_CASE("ForEachIndex.HeterogeneousRange" * doctest::timeout(300)) {
+  std::atomic<size_t> counter(0);
+	tf::Executor ex;
+	tf::Taskflow flow;
+
+  std::size_t from = 1;
+  std::size_t to = 10;
+  int step = 1;
+
+	flow.for_each_index(from, to, step, [&](int i) {
+		counter.fetch_add(i, std::memory_order_relaxed);
+	});
+	ex.run(flow).wait();
+  REQUIRE(counter == to * (to + 1) / 2);
 }
 
 // ----------------------------------------------------------------------------

--- a/unittests/test_for_each.cpp
+++ b/unittests/test_for_each.cpp
@@ -582,7 +582,7 @@ TEST_CASE("ForEachIndex.NegativeIndex.4threads" * doctest::timeout(300)) {
 // ----------------------------------------------------------------------------
 
 TEST_CASE("ForEachIndex.InvalidRange" * doctest::timeout(300)) {
-	std::atomic<size_t> counter(0);
+  std::atomic<size_t> counter(0);
 	tf::Executor ex;
 	tf::Taskflow flow;
 	flow.for_each_index(0, -1, 1, [&](int i) {
@@ -597,7 +597,7 @@ TEST_CASE("ForEachIndex.InvalidRange" * doctest::timeout(300)) {
 // ----------------------------------------------------------------------------
 
 TEST_CASE("ForEachIndex.HeterogeneousRange" * doctest::timeout(300)) {
-  std::atomic<size_t> counter(0);
+	std::atomic<size_t> counter(0);
 	tf::Executor ex;
 	tf::Taskflow flow;
 

--- a/unittests/test_for_each.cpp
+++ b/unittests/test_for_each.cpp
@@ -582,14 +582,14 @@ TEST_CASE("ForEachIndex.NegativeIndex.4threads" * doctest::timeout(300)) {
 // ----------------------------------------------------------------------------
 
 TEST_CASE("ForEachIndex.InvalidRange" * doctest::timeout(300)) {
-  std::atomic<size_t> counter(0);
+	std::atomic<size_t> counter(0);
 	tf::Executor ex;
 	tf::Taskflow flow;
 	flow.for_each_index(0, -1, 1, [&](int i) {
 		counter.fetch_add(i, std::memory_order_relaxed);
 	});
 	ex.run(flow).wait();
-  REQUIRE(counter == 0);
+	REQUIRE(counter == 0);
 }
 
 // ----------------------------------------------------------------------------
@@ -601,15 +601,15 @@ TEST_CASE("ForEachIndex.HeterogeneousRange" * doctest::timeout(300)) {
 	tf::Executor ex;
 	tf::Taskflow flow;
 
-  std::size_t from = 1;
-  std::size_t to = 10;
-  int step = 1;
+	std::size_t from = 1;
+	std::size_t to = 10;
+	int step = 1;
 
 	flow.for_each_index(from, to, step, [&](int i) {
 		counter.fetch_add(i, std::memory_order_relaxed);
 	});
 	ex.run(flow).wait();
-  REQUIRE(counter == to * (to + 1) / 2);
+	REQUIRE(counter == to * (to + 1) / 2);
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
**Problem description**: https://github.com/taskflow/taskflow/issues/610
Function `for_each_index` has following signature: `template <typename B, typename E, typename S, typename C, typename P> Task FlowBuilder::for_each_index(B beg, E end, S inc, C c, P part);` which implies, that range might be heterogeneous: for example, `beg` and `end` can be of type `size_t`, and `inc` can be `int`.

However, it's not the case, because C++ compilers fail to deduce type on functions `is_range_invalid` and `distance`, which are used under the hood of `for_each_index`, because they are homogeneous. So, before this pull-request, something like following example wouldn't compile, because compiler fails to deduce types of arguments for homogeneous functions `distance` and `is_range_invalid`:
```
template<typename F>
void parallel_for(size_t from, size_t to, F&& f) {
    tf.for_each_index(from, to, 1, std::forward<F>(f));
}
```

**Result**
This PR fixes this problem and adds a unit-test with an example of heterogeneous call to `for_each_index`