### PR TITLE
bugfix(doxygen): update conditional tasking in doxygen/cookbook/conditional_tasking.dox

### DIFF
--- a/doxygen/cookbook/conditional_tasking.dox
+++ b/doxygen/cookbook/conditional_tasking.dox
@@ -518,20 +518,25 @@ auto loop = [&, i=bool{true}, c = int(0)]() mutable -> tf::SmallVector<int> {
   }
   else {
     counter.fetch_add(1, std::memory_order_relaxed);
-    return {++c < 10 ? 0 : -1};
+    return {++c < 10 ? 0 : 1};
   }
-}
-auto A = taskflow.emplace([](){});
-auto B = taskflow.emplace(loop);
-auto C = taskflow.emplace(loop);
-auto D = taskflow.emplace(loop);
+};
+auto init = taskflow.emplace([](){}).name("init");
+auto A = taskflow.emplace(loop).name("A");
+auto B = taskflow.emplace(loop).name("B");
+auto C = taskflow.emplace(loop).name("C");
+auto D = taskflow.emplace(loop).name("D");
 
-A.precede(B);
+init.precede(A);
+A.precede(A, B);
 B.precede(B, C);
 C.precede(C, D);
 D.precede(D);
 
 executor.run(taskflow).wait();  // counter == 40
+taskflow.dump(std::cout);
+
+std::cout << "counter == " << counter << '\n';
 @endcode
 
 @dotfile images/multi-condition-task-2.dot


### PR DESCRIPTION
The original example code contains the following issues:

1. The expression `++c < 10 ? 0 : -1` should return 1 in the false case; otherwise, the executor will not be able to find the successor task to execute, and the final result of count will be 10.
2. A source task should be added; otherwise, the taskflow will encounter a "no source task" error.
3. Task A should also be a `loop` task and a predecessor task for (A, B).

Additionally, I have added some code to help newcomers debug and visualize the graph more easily.

Lastly, could someone please explain the purpose of the if(i) code block:
https://github.com/taskflow/taskflow/blob/master/doxygen/cookbook/conditional_tasking.dox#L515-518

 Thanks advance.