### PR TITLE
Fix the `Executor` class not appearing in generator docs, patch warnings

### DIFF
--- a/doxygen/Doxyfile
+++ b/doxygen/Doxyfile
@@ -172,7 +172,7 @@ INLINE_INHERITED_MEMB  = NO
 # shortest path that makes the file name unique will be used
 # The default value is: YES.
 
-FULL_PATH_NAMES        = NO
+FULL_PATH_NAMES        = YES
 
 # The STRIP_FROM_PATH tag can be used to strip a user-defined part of the path.
 # Stripping is only done if one of the specified strings matches the left-hand
@@ -184,7 +184,7 @@ FULL_PATH_NAMES        = NO
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        =
+STRIP_FROM_PATH        = ..
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which
@@ -193,7 +193,7 @@ STRIP_FROM_PATH        =
 # specify the list of include paths that are normally passed to the compiler
 # using the -I flag.
 
-STRIP_FROM_INC_PATH    =
+STRIP_FROM_INC_PATH    = ..
 
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter (but
 # less readable) file names. This can be useful is your file systems doesn't
@@ -863,7 +863,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = NO
+QUIET                  = YES
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error (stderr) by doxygen. If WARNINGS is set to YES
@@ -2412,7 +2412,7 @@ PERLMOD_MAKEVAR_PREFIX =
 # C-preprocessor directives found in the sources and include files.
 # The default value is: YES.
 
-ENABLE_PREPROCESSING   = NO
+ENABLE_PREPROCESSING   = YES
 
 # If the MACRO_EXPANSION tag is set to YES, doxygen will expand all macro names
 # in the source code. If set to NO, only conditional compilation will be
@@ -2462,7 +2462,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = DOXYGEN_GENERATING_OUTPUT
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/taskflow/core/executor.hpp
+++ b/taskflow/core/executor.hpp
@@ -1107,6 +1107,8 @@ class Executor {
 
 };
 
+#ifndef DOXYGEN_GENERATING_OUTPUT
+
 // Constructor
 inline Executor::Executor(size_t N) :
   _MAX_STEALS ((N+1) << 1),
@@ -2398,7 +2400,7 @@ auto Runtime::async(P&& params, F&& f) {
   return _async(*pt::worker, std::forward<P>(params), std::forward<F>(f));
 }
 
-
+#endif
 
 
 

--- a/taskflow/core/graph.hpp
+++ b/taskflow/core/graph.hpp
@@ -292,6 +292,8 @@ class Runtime {
   @param params task parameters
   @param f callable
 
+  <p><!-- Doxygen warning workaround --></p>
+
   @code{.cpp}
   taskflow.emplace([&](tf::Runtime& rt){
     auto future = rt.async("my task", [](){});
@@ -334,7 +336,9 @@ class Runtime {
   @tparam F callable type
   @param params task parameters
   @param f callable
-  
+
+  <p><!-- Doxygen warning workaround --></p>
+
   @code{.cpp}
   taskflow.emplace([&](tf::Runtime& rt){
     rt.silent_async("my task", [](){});

--- a/taskflow/core/taskflow.hpp
+++ b/taskflow/core/taskflow.hpp
@@ -251,7 +251,9 @@ class Taskflow : public FlowBuilder {
 
     @param from from task (dependent)
     @param to to task (successor)
-  
+
+    <p><!-- Doxygen warning workaround --></p>
+
     @code{.cpp}
     tf::Taskflow taskflow;
     auto a = taskflow.placeholder().name("a");


### PR DESCRIPTION
Original issue on the m.css repo: mosra/m.css#250

This PR excludes the `Executor` implementation from Doxygen processing as proposed in #605, just with a more unique name (@tjhei I listed you as a co-author). Additionally fixes warnings related to filesystem hierarchy by enabling FULL_PATH_NAMES + STRIP_FROM_PATH. That ultimately results in the same output as before, but with an effect that the directory structure doesn't have to be guessed from incomplete information by m.css. The warnings manifest as the following as of mosra/m.css@083c7a87dcca80027a4bc9c5e6db3bab4babffb0:

> WARNING:root:potential issue: the parent of algorithm/ is taskflow/ which is not a prefix, you may want to enable FULL_PATH_NAMES together with STRIP_FROM_PATH and STRIP_FROM_INC_PATH to preserve filesystem hierarchy

Finally, adds workarounds for certain Doxygen parsing warts, where `@param` is put together with the immediately following `@code` into a single paragraph, causing warnings like below. The paragraph ends up being empty and is thus removed, again resulting in the same generated output as before, just without the warnings.

> WARNING:root:classtf_1_1Runtime.xml: inline code has multiple lines, fallback to a code block

(Just for completeness -- inline code higlighting [can look for example like this](https://doc.magnum.graphics/magnum/types.html), note the C++ and GLSL keywords being bold. [Documentation on how to do that is here.](https://mcss.mosra.cz/documentation/doxygen/#code-highlighting))