### PR TITLE
only include CTest if building tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,9 +293,6 @@ include_directories(${PROJECT_SOURCE_DIR})
 # must-have package include
 # -----------------------------------------------------------------------------
 
-# Enable test
-include(CTest)
-
 # Find pthread package
 find_package(Threads REQUIRED)
 
@@ -322,6 +319,7 @@ endif(TF_BUILD_EXAMPLES)
 # Unittest
 # -----------------------------------------------------------------------------
 if(TF_BUILD_TESTS)
+  include(CTest)
   add_subdirectory(unittests)
 endif(TF_BUILD_TESTS)
 


### PR DESCRIPTION
To avoid unnecessary test related targets when CMake build option `TF_BUILD_TESTS = OFF` we should only `include(CTest)` when `TF_BUILD_TESTS = ON`