### PR TITLE
Example for running processes in task graph

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ option(TF_BUILD_PROFILER "Enables builds of profiler" OFF)
 option(TF_BUILD_CUDA "Enables builds of cuda code" OFF)
 option(TF_BUILD_TESTS "Enables builds of tests" ON)
 option(TF_BUILD_EXAMPLES "Enables builds of examples" ON)
+option(TF_BUILD_PROCESS_EXAMPLE "Enables build of process example, needs Boost" OFF)
 option(TF_BUILD_MODULES "Enables C++ modules" OFF)
 
 # project-specific variables

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -40,6 +40,7 @@ list(APPEND TF_EXAMPLES
   task_visitor
 )
 
+
 foreach(example IN LISTS TF_EXAMPLES)
   add_executable(${example} ${example}.cpp)
   target_link_libraries(
@@ -99,3 +100,11 @@ endif()
 #target_link_libraries(
 #  visualization_dsl TaskflowDSL tf::default_settings
 #)
+
+
+if(TF_BUILD_PROCESS_EXAMPLE)
+    if(NOT TF_BUILD_EXAMPLES)
+        message(FATAL_ERROR "Process example needs option TF_BUILD_EXAMPLE")
+    endif()
+    add_subdirectory(run_processes)
+endif()

--- a/examples/run_processes/CMakeLists.txt
+++ b/examples/run_processes/CMakeLists.txt
@@ -1,0 +1,16 @@
+
+cmake_policy(SET CMP0167 OLD)
+
+find_package(Boost REQUIRED COMPONENTS system)
+
+set(SRCS_RUN_PROCESSES
+    run_processes.cpp
+    subprocess.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/path_to_executables.cpp
+)
+
+add_executable( run_processes ${SRCS_RUN_PROCESSES} )
+target_link_libraries(run_processes PRIVATE Boost::headers Boost::system)
+target_include_directories(run_processes PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/path_to_executables.cpp INPUT ${CMAKE_CURRENT_SOURCE_DIR}/path_to_executables.cpp.in )

--- a/examples/run_processes/path_to_executables.cpp.in
+++ b/examples/run_processes/path_to_executables.cpp.in
@@ -1,0 +1,11 @@
+#include "path_to_executables.hpp"
+
+const char *pathToCancelExec()
+{
+   return "$<TARGET_FILE:cancel>";
+}
+
+const char *pathToFibonacciExec()
+{
+   return "$<TARGET_FILE:fibonacci>";
+}

--- a/examples/run_processes/path_to_executables.hpp
+++ b/examples/run_processes/path_to_executables.hpp
@@ -1,0 +1,4 @@
+#pragma once
+
+const char *pathToCancelExec();
+const char *pathToFibonacciExec();

--- a/examples/run_processes/run_processes.cpp
+++ b/examples/run_processes/run_processes.cpp
@@ -1,0 +1,49 @@
+// A simple example to run executables in subprocesses and maintain
+// the following task dependencies.
+//
+//           +--------------------+
+//     +---->| B run fibonacci 15 |-----+
+//     |     +--------------------+     |
+//   +--------------+           +-------v------+
+//   | A run cancel |           | D run cancel |
+//   +--------------+           +-------^------+
+//     |     +-------------------+      |
+//     +---->| C run fibonacci 21|------+
+//           +-------------------+
+//
+#include <taskflow/taskflow.hpp>
+#include "subprocess.hpp" // for blocking subprocess invocation
+#include "path_to_executables.hpp"  // path to compiled examples fibonacci and simple
+
+
+
+std::string fibonacciCall(int num)
+{
+    return std::string{pathToFibonacciExec()} + " " + std::to_string(num);
+}
+
+int main(){
+
+    tf::Executor executor;
+    tf::Taskflow taskflow("simple");
+
+    auto [A, B, C, D] = taskflow.emplace(
+        []() { std::cout << "TaskA\n"; runBlocking(pathToCancelExec()); },
+        []() { std::cout << "TaskB\n"; runBlocking(fibonacciCall(15)); },
+        []() { std::cout << "TaskC\n"; runBlocking(fibonacciCall(21)); },
+        []() { std::cout << "TaskD\n"; runBlocking(pathToCancelExec());}
+        );
+
+    A.name("A");
+    B.name("B");
+    C.name("C");
+    D.name("D");
+
+    A.precede(B, C);  // A runs before B and C
+    D.succeed(B, C);  // D runs after  B and C
+
+    executor.run(taskflow).wait();
+
+    return 0;
+}
+

--- a/examples/run_processes/subprocess.cpp
+++ b/examples/run_processes/subprocess.cpp
@@ -1,0 +1,122 @@
+#include "subprocess.hpp"
+#include <iostream>
+#include <boost/asio.hpp>
+#include <boost/process.hpp>
+#include <boost/asio.hpp>
+#include <boost/process.hpp>
+
+#include <boost/process.hpp>
+#include <boost/process.hpp>
+
+namespace bp = boost::process;
+
+
+struct CommandAndDir
+{
+    std::string commandLine;
+    std::filesystem::path directory;
+};
+
+
+
+class SubProcess
+{
+public:
+    SubProcess( const CommandAndDir &command)
+        : m_command(command)
+        , bufErr(1000)
+        , bufOut(1000)
+        , apErr(m_ioc)
+        , apOut(m_ioc)
+        , apIn(m_ioc)
+    {
+    }
+
+    void run();
+    int wait();
+
+private:
+    void readStdOut();
+    void readStdErr();
+
+    const CommandAndDir &m_command;
+    std::vector<char> bufErr;
+    std::vector<char> bufOut;
+
+    boost::asio::io_context m_ioc;
+    boost::process::async_pipe apErr;
+    boost::process::async_pipe apOut;
+    boost::process::async_pipe apIn;
+    std::unique_ptr<boost::process::child> m_child;
+};
+
+void SubProcess::run()
+{
+    if(m_command.directory == std::filesystem::path{})
+    {
+        m_child = std::make_unique<bp::child>(m_command.commandLine
+                                              , bp::std_err > apErr
+                                              , bp::std_out > apOut);
+    } else {
+        m_child = std::make_unique<bp::child>(m_command.commandLine
+                                              , bp::std_err > apErr
+                                              , bp::std_out > apOut
+                                              , bp::start_dir(m_command.directory.string()));
+    }
+
+    readStdOut();
+    readStdErr();
+}
+
+int SubProcess::wait()
+{
+    m_ioc.run();
+    if(m_child) {
+        m_child->wait();
+        return m_child->exit_code();
+    }
+    return EXIT_FAILURE;
+}
+
+void SubProcess::readStdOut()
+{
+    apOut.async_read_some(boost::asio::buffer(bufOut),
+                          [this](const boost::system::error_code &ec, std::size_t size){
+                              std::cout << std::string{bufOut.cbegin(), bufOut.cbegin() + size} ;
+                              if(size != 0) {
+                                  readStdOut();
+                              }
+                          });
+
+}
+
+void SubProcess::readStdErr()
+{
+    apErr.async_read_some(boost::asio::buffer(bufErr),
+                          [this](const boost::system::error_code &ec, std::size_t size){
+                              std::cerr << std::string{bufErr.cbegin(), bufErr.cbegin() + size} ;
+                              if(size != 0) {
+                                  readStdErr();
+                              }
+                          });
+}
+
+int runBlocking(const CommandAndDir &command)
+{
+    SubProcess subProcess{command};
+    subProcess.run();
+    const int exitResult = subProcess.wait();
+    return exitResult;
+}
+
+int runBlocking(const std::string &executable)
+{
+    CommandAndDir command{executable};
+    return runBlocking(command);
+}
+
+int runBlocking(const std::string &command, const std::filesystem::path &directory)
+{
+    CommandAndDir commandAndDir{command, directory};
+    return runBlocking(command);
+}

--- a/examples/run_processes/subprocess.hpp
+++ b/examples/run_processes/subprocess.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+
+// Run an executable as a child process, block till process is completed.
+// Write output of process to stdout/stderr.
+// Return exit code of process.
+int runBlocking(const std::string &command);
+int runBlocking(const std::string &command, const std::filesystem::path &directory);
+
+


### PR DESCRIPTION
There were numerous requests to run processes with a dependency graph defined by taskflow. Imagine we had a blocking function which forks a child process and waits for the child to complete - this would be the missing piece to have a graph of processes. The blocking function would also pipe the stdout and stderr of subprocesses to the calling process. This pull request contains such a blocking function to fork a process and an example that demonstrates how this looks in a taskflow context. 
The concept opens a plethora of new applications. For example gmake like applications could now be expressed in C++ and benefit from C++ tooling. Defined graphs could be introspected and exported to ninja format to use an open task runner......   and so on.

 