### PR TITLE
Fix AppleClang compile error in tsq.hpp with undeclared identifiers

### DIFF
--- a/taskflow/core/tsq.hpp
+++ b/taskflow/core/tsq.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../taskflow.hpp"
 #include "../utility/macros.hpp"
 #include "../utility/traits.hpp"
 

--- a/taskflow/core/tsq.hpp
+++ b/taskflow/core/tsq.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "../taskflow.hpp"
 #include "../utility/macros.hpp"
 #include "../utility/traits.hpp"
 
@@ -8,6 +7,26 @@
 @file tsq.hpp
 @brief task queue include file
 */
+
+#ifndef TF_DEFAULT_BOUNDED_TASK_QUEUE_LOG_SIZE 
+/**
+@def TF_DEFAULT_BOUNDED_TASK_QUEUE_LOG_SIZE
+
+This macro defines the default size of the bounded task queue in Log2. 
+Bounded task queue is used by each worker.
+*/
+  #define TF_DEFAULT_BOUNDED_TASK_QUEUE_LOG_SIZE 8
+#endif
+
+#ifndef TF_DEFAULT_UNBOUNDED_TASK_QUEUE_LOG_SIZE 
+/**
+@def TF_DEFAULT_UNBOUNDED_TASK_QUEUE_LOG_SIZE
+
+This macro defines the default size of the unbounded task queue in Log2.
+Unbounded task queue is used by the executor.
+*/
+  #define TF_DEFAULT_UNBOUNDED_TASK_QUEUE_LOG_SIZE 10
+#endif
 
 namespace tf {
 

--- a/taskflow/taskflow.hpp
+++ b/taskflow/taskflow.hpp
@@ -7,27 +7,6 @@
 // + TF_ENABLE_ATOMIC_NOTIFIER : enable atomic notifier (required C++20)
 //
 
-#ifndef TF_DEFAULT_BOUNDED_TASK_QUEUE_LOG_SIZE 
-/**
-@def TF_DEFAULT_BOUNDED_TASK_QUEUE_LOG_SIZE
-
-This macro defines the default size of the bounded task queue in Log2. 
-Bounded task queue is used by each worker.
-*/
-  #define TF_DEFAULT_BOUNDED_TASK_QUEUE_LOG_SIZE 8
-#endif
-
-#ifndef TF_DEFAULT_UNBOUNDED_TASK_QUEUE_LOG_SIZE 
-/**
-@def TF_DEFAULT_UNBOUNDED_TASK_QUEUE_LOG_SIZE
-
-This macro defines the default size of the unbounded task queue in Log2.
-Unbounded task queue is used by the executor.
-*/
-  #define TF_DEFAULT_UNBOUNDED_TASK_QUEUE_LOG_SIZE 10
-#endif
-
-
 #include "core/executor.hpp"
 #include "core/async.hpp"
 


### PR DESCRIPTION
Fix AppleClang compile error in tsq.hpp with undeclared identifiers 'TF_DEFAULT_UNBOUNDED_TASK_QUEUE_LOG_SIZE' and 'TF_DEFAULT_UNBOUNDED_TASK_QUEUE_LOG_SIZE' (close #650)