### PR TITLE
Enable use of 'Taskflow::Taskflow' for all consumption styles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,6 +301,7 @@ find_package(Threads REQUIRED)
 # -----------------------------------------------------------------------------
 
 add_library(${PROJECT_NAME} INTERFACE)
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_17)
 target_link_libraries(${PROJECT_NAME} INTERFACE ${ATOMIC_LIBRARY} Threads::Threads)
 target_include_directories(${PROJECT_NAME} INTERFACE


### PR DESCRIPTION
Create an ALIAS target that matches the exported target name (TaskFlow::Taskflow).  This allows consumers to be agnostic of how Taskflow was brought into the build.  ie: a consuming project may use `Taskflow::Taskflow` and it will work with an external packaging of Taskflow, and also when built-on-the-fly (eg: via git submodule).