### PR TITLE
Use 'requires' keyword to support C++20 features

### DIFF
--- a/taskflow/core/async.hpp
+++ b/taskflow/core/async.hpp
@@ -78,9 +78,14 @@ inline void Executor::_tear_down_async(Worker& worker, Node* node, Node*& cache)
 // ----------------------------------------------------------------------------
 
 // Function: silent_dependent_async
+#if __cplusplus >= TF_CPP20
+template <typename F, typename... Tasks>
+requires all_same_v<AsyncTask, std::decay_t<Tasks>...>
+#else
 template <typename F, typename... Tasks,
   std::enable_if_t<all_same_v<AsyncTask, std::decay_t<Tasks>...>, void>*
 >
+#endif
 tf::AsyncTask Executor::silent_dependent_async(F&& func, Tasks&&... tasks) {
   return silent_dependent_async(
     DefaultTaskParams{}, std::forward<F>(func), std::forward<Tasks>(tasks)...
@@ -88,9 +93,14 @@ tf::AsyncTask Executor::silent_dependent_async(F&& func, Tasks&&... tasks) {
 }
 
 // Function: silent_dependent_async
+#if __cplusplus >= TF_CPP20
+template <typename P, typename F, typename... Tasks>
+requires is_task_params_v<P> && all_same_v<AsyncTask, std::decay_t<Tasks>...>
+#else
 template <typename P, typename F, typename... Tasks,
   std::enable_if_t<is_task_params_v<P> && all_same_v<AsyncTask, std::decay_t<Tasks>...>, void>*
 >
+#endif
 tf::AsyncTask Executor::silent_dependent_async(
   P&& params, F&& func, Tasks&&... tasks 
 ){
@@ -101,17 +111,27 @@ tf::AsyncTask Executor::silent_dependent_async(
 }
 
 // Function: silent_dependent_async
+#if __cplusplus >= TF_CPP20
+template <typename F, typename I>
+requires (!std::is_same_v<std::decay_t<I>, AsyncTask>)
+#else
 template <typename F, typename I,
   std::enable_if_t<!std::is_same_v<std::decay_t<I>, AsyncTask>, void>*
 >
+#endif
 tf::AsyncTask Executor::silent_dependent_async(F&& func, I first, I last) {
   return silent_dependent_async(DefaultTaskParams{}, std::forward<F>(func), first, last);
 }
 
 // Function: silent_dependent_async
+#if __cplusplus >= TF_CPP20
+template <typename P, typename F, typename I>
+requires (is_task_params_v<P> && !std::is_same_v<std::decay_t<I>, AsyncTask>)
+#else
 template <typename P, typename F, typename I,
   std::enable_if_t<is_task_params_v<P> && !std::is_same_v<std::decay_t<I>, AsyncTask>, void>*
 >
+#endif
 tf::AsyncTask Executor::silent_dependent_async(
   P&& params, F&& func, I first, I last
 ) {
@@ -141,17 +161,27 @@ tf::AsyncTask Executor::silent_dependent_async(
 // ----------------------------------------------------------------------------
 
 // Function: dependent_async
+#if __cplusplus >= TF_CPP20
+template <typename F, typename... Tasks>
+requires all_same_v<AsyncTask, std::decay_t<Tasks>...>
+#else
 template <typename F, typename... Tasks,
   std::enable_if_t<all_same_v<AsyncTask, std::decay_t<Tasks>...>, void>*
 >
+#endif
 auto Executor::dependent_async(F&& func, Tasks&&... tasks) {
   return dependent_async(DefaultTaskParams{}, std::forward<F>(func), std::forward<Tasks>(tasks)...);
 }
 
 // Function: dependent_async
+#if __cplusplus >= TF_CPP20
+template <typename P, typename F, typename... Tasks>
+requires is_task_params_v<P> && all_same_v<AsyncTask, std::decay_t<Tasks>...>
+#else
 template <typename P, typename F, typename... Tasks,
   std::enable_if_t<is_task_params_v<P> && all_same_v<AsyncTask, std::decay_t<Tasks>...>, void>*
 >
+#endif
 auto Executor::dependent_async(P&& params, F&& func, Tasks&&... tasks) {
   std::array<AsyncTask, sizeof...(Tasks)> array = { std::forward<Tasks>(tasks)... };
   return dependent_async(
@@ -160,17 +190,27 @@ auto Executor::dependent_async(P&& params, F&& func, Tasks&&... tasks) {
 }
 
 // Function: dependent_async
+#if __cplusplus >= TF_CPP20
+template <typename F, typename I>
+requires (!std::is_same_v<std::decay_t<I>, AsyncTask>)
+#else
 template <typename F, typename I,
   std::enable_if_t<!std::is_same_v<std::decay_t<I>, AsyncTask>, void>*
 >
+#endif
 auto Executor::dependent_async(F&& func, I first, I last) {
   return dependent_async(DefaultTaskParams{}, std::forward<F>(func), first, last);
 }
 
 // Function: dependent_async
+#if __cplusplus >= TF_CPP20
+template <typename P, typename F, typename I>
+requires (is_task_params_v<P> && !std::is_same_v<std::decay_t<I>, AsyncTask>)
+#else
 template <typename P, typename F, typename I,
   std::enable_if_t<is_task_params_v<P> && !std::is_same_v<std::decay_t<I>, AsyncTask>, void>*
 >
+#endif
 auto Executor::dependent_async(P&& params, F&& func, I first, I last) {
   
   _increment_topology();

--- a/taskflow/core/executor.hpp
+++ b/taskflow/core/executor.hpp
@@ -738,9 +738,15 @@ class Executor {
 
   This member function is thread-safe.
   */
+
+#if __cplusplus >= TF_CPP20
+  template <typename F, typename... Tasks>
+  requires all_same_v<AsyncTask, std::decay_t<Tasks>...>
+#else
   template <typename F, typename... Tasks,
     std::enable_if_t<all_same_v<AsyncTask, std::decay_t<Tasks>...>, void>* = nullptr
   >
+#endif
   tf::AsyncTask silent_dependent_async(F&& func, Tasks&&... tasks);
   
   /**
@@ -774,9 +780,14 @@ class Executor {
 
   This member function is thread-safe.
   */
+#if __cplusplus >= TF_CPP20
+  template <typename P, typename F, typename... Tasks>
+  requires is_task_params_v<P> && all_same_v<AsyncTask, std::decay_t<Tasks>...>
+#else
   template <typename P, typename F, typename... Tasks,
     std::enable_if_t<is_task_params_v<P> && all_same_v<AsyncTask, std::decay_t<Tasks>...>, void>* = nullptr
   >
+#endif
   tf::AsyncTask silent_dependent_async(P&& params, F&& func, Tasks&&... tasks);
   
   /**
@@ -811,9 +822,14 @@ class Executor {
 
   This member function is thread-safe.
   */
-  template <typename F, typename I, 
+#if __cplusplus >= TF_CPP20
+  template <typename F, typename I>
+  requires (!std::is_same_v<std::decay_t<I>, AsyncTask>)
+#else
+  template <typename F, typename I,
     std::enable_if_t<!std::is_same_v<std::decay_t<I>, AsyncTask>, void>* = nullptr
   >
+#endif
   tf::AsyncTask silent_dependent_async(F&& func, I first, I last);
   
   /**
@@ -850,9 +866,14 @@ class Executor {
 
   This member function is thread-safe.
   */
-  template <typename P, typename F, typename I, 
+#if __cplusplus >= TF_CPP20
+  template <typename P, typename F, typename I>
+  requires (is_task_params_v<P> && !std::is_same_v<std::decay_t<I>, AsyncTask>)
+#else
+  template <typename P, typename F, typename I,
     std::enable_if_t<is_task_params_v<P> && !std::is_same_v<std::decay_t<I>, AsyncTask>, void>* = nullptr
   >
+#endif
   tf::AsyncTask silent_dependent_async(P&& params, F&& func, I first, I last);
   
   // --------------------------------------------------------------------------
@@ -896,9 +917,14 @@ class Executor {
 
   This member function is thread-safe.
   */
+#if __cplusplus >= TF_CPP20
+    template <typename F, typename... Tasks>
+    requires all_same_v<AsyncTask, std::decay_t<Tasks>...>
+#else
   template <typename F, typename... Tasks,
     std::enable_if_t<all_same_v<AsyncTask, std::decay_t<Tasks>...>, void>* = nullptr
   >
+#endif
   auto dependent_async(F&& func, Tasks&&... tasks);
   
   /**
@@ -942,9 +968,14 @@ class Executor {
 
   This member function is thread-safe.
   */
+#if __cplusplus >= TF_CPP20
+  template <typename P, typename F, typename... Tasks>
+  requires is_task_params_v<P> && all_same_v<AsyncTask, std::decay_t<Tasks>...>
+#else
   template <typename P, typename F, typename... Tasks,
     std::enable_if_t<is_task_params_v<P> && all_same_v<AsyncTask, std::decay_t<Tasks>...>, void>* = nullptr
   >
+#endif
   auto dependent_async(P&& params, F&& func, Tasks&&... tasks);
   
   /**
@@ -987,9 +1018,14 @@ class Executor {
 
   This member function is thread-safe.
   */
+#if __cplusplus >= TF_CPP20
+  template <typename F, typename I>
+  requires (!std::is_same_v<std::decay_t<I>, AsyncTask>)
+#else
   template <typename F, typename I,
     std::enable_if_t<!std::is_same_v<std::decay_t<I>, AsyncTask>, void>* = nullptr
   >
+#endif
   auto dependent_async(F&& func, I first, I last);
   
   /**
@@ -1036,9 +1072,14 @@ class Executor {
 
   This member function is thread-safe.
   */
+#if __cplusplus >= TF_CPP20
+  template <typename P, typename F, typename I>
+  requires (is_task_params_v<P> && !std::is_same_v<std::decay_t<I>, AsyncTask>)
+#else
   template <typename P, typename F, typename I,
     std::enable_if_t<is_task_params_v<P> && !std::is_same_v<std::decay_t<I>, AsyncTask>, void>* = nullptr
   >
+#endif
   auto dependent_async(P&& params, F&& func, I first, I last);
 
   private:


### PR DESCRIPTION
This pull request updates the code to use C++20's `requires` keyword in place of SFINAE-based constraints.  This change brings several benefits:

1.  **Improved Readability**: `requires` offers a cleaner and more intuitive way to express template constraints.  In contrast, SFINAE requires constraints to be embedded within the template parameter list using `enable_if_t` and a special `nullptr`.  By separating the constraints from the template parameters, `requires` improves code clarity and makes the intention of the template easier to understand.

2.  **Enhanced Type Safety**: Using `requires` allows the compiler to more easily validate template parameters against the specified conditions, providing better type-checking and more precise error messages during compilation. When a constraint fails, the compiler can now show exactly which concept check failed, making it easier to pinpoint and fix issues. This helps catch potential errors early, reducing the likelihood of subtle bugs that might arise from more complex SFINAE conditions.

3.  **Aligning with C++20 Standards**: By using `requires`, the code is more in line with modern C++ standards.  This approach embraces C++20 features, ensuring that the code remains up-to-date and takes advantage of the latest language improvements.