### PR TITLE
Fix MSVC macro conflict

### DIFF
--- a/taskflow/algorithm/partitioner.hpp
+++ b/taskflow/algorithm/partitioner.hpp
@@ -314,7 +314,7 @@ class GuidedPartitioner : public PartitionerBase<C> {
           if(curr_b >= N) {
             return;
           }
-          func(curr_b, std::min(curr_b + chunk_size, N));
+          func(curr_b, (std::min)(curr_b + chunk_size, N));
         }
         break;
       }
@@ -325,7 +325,7 @@ class GuidedPartitioner : public PartitionerBase<C> {
           q = chunk_size;
         }
         //size_t curr_e = (q <= r) ? curr_b + q : N;
-        size_t curr_e = std::min(curr_b + q, N);
+        size_t curr_e = (std::min)(curr_b + q, N);
         if(next.compare_exchange_strong(curr_b, curr_e, std::memory_order_relaxed,
                                                         std::memory_order_relaxed)) {
           func(curr_b, curr_e);
@@ -362,7 +362,7 @@ class GuidedPartitioner : public PartitionerBase<C> {
           if(curr_b >= N) {
             return;
           }
-          if(func(curr_b, std::min(curr_b + chunk_size, N))) {
+          if(func(curr_b, (std::min)(curr_b + chunk_size, N))) {
             return;
           }
         }
@@ -375,7 +375,7 @@ class GuidedPartitioner : public PartitionerBase<C> {
           q = chunk_size;
         }
         //size_t curr_e = (q <= r) ? curr_b + q : N;
-        size_t curr_e = std::min(curr_b + q, N);
+        size_t curr_e = (std::min)(curr_b + q, N);
         if(next.compare_exchange_strong(curr_b, curr_e, std::memory_order_relaxed,
                                                         std::memory_order_relaxed)) {
           if(func(curr_b, curr_e)) {
@@ -477,7 +477,7 @@ class DynamicPartitioner : public PartitionerBase<C> {
     size_t curr_b = next.fetch_add(chunk_size, std::memory_order_relaxed);
 
     while(curr_b < N) {
-      func(curr_b, std::min(curr_b + chunk_size, N));
+      func(curr_b, (std::min)(curr_b + chunk_size, N));
       curr_b = next.fetch_add(chunk_size, std::memory_order_relaxed);
     }
   }
@@ -496,7 +496,7 @@ class DynamicPartitioner : public PartitionerBase<C> {
     size_t curr_b = next.fetch_add(chunk_size, std::memory_order_relaxed);
 
     while(curr_b < N) {
-      if(func(curr_b, std::min(curr_b + chunk_size, N))) {
+      if(func(curr_b, (std::min)(curr_b + chunk_size, N))) {
         return;
       }
       curr_b = next.fetch_add(chunk_size, std::memory_order_relaxed);
@@ -609,7 +609,7 @@ class StaticPartitioner : public PartitionerBase<C> {
   ) {
     size_t stride = W * chunk_size;
     while(curr_b < N) {
-      size_t curr_e = std::min(curr_b + chunk_size, N);
+      size_t curr_e = (std::min)(curr_b + chunk_size, N);
       func(curr_b, curr_e);
       curr_b += stride;
     }
@@ -626,7 +626,7 @@ class StaticPartitioner : public PartitionerBase<C> {
   ) {
     size_t stride = W * chunk_size;
     while(curr_b < N) {
-      size_t curr_e = std::min(curr_b + chunk_size, N);
+      size_t curr_e = (std::min)(curr_b + chunk_size, N);
       if(func(curr_b, curr_e)) {
         return;
       }
@@ -743,8 +743,8 @@ class RandomPartitioner : public PartitionerBase<C> {
       std::swap(b1, b2);
     }
 
-    b1 = std::max(b1, size_t{1});
-    b2 = std::max(b2, b1 + 1);
+    b1 = (std::max)(b1, size_t{1});
+    b2 = (std::max)(b2, b1 + 1);
 
     return {b1, b2};
   }
@@ -772,7 +772,7 @@ class RandomPartitioner : public PartitionerBase<C> {
     size_t curr_b = next.fetch_add(chunk_size, std::memory_order_relaxed);
 
     while(curr_b < N) {
-      func(curr_b, std::min(curr_b + chunk_size, N));
+      func(curr_b, (std::min)(curr_b + chunk_size, N));
       chunk_size = dist(engine);
       curr_b = next.fetch_add(chunk_size, std::memory_order_relaxed);
     }
@@ -797,7 +797,7 @@ class RandomPartitioner : public PartitionerBase<C> {
     size_t curr_b = next.fetch_add(chunk_size, std::memory_order_relaxed);
 
     while(curr_b < N) {
-      if(func(curr_b, std::min(curr_b + chunk_size, N))){
+      if(func(curr_b, (std::min)(curr_b + chunk_size, N))){
         return;
       }
       chunk_size = dist(engine);

--- a/taskflow/core/observer.hpp
+++ b/taskflow/core/observer.hpp
@@ -537,27 +537,27 @@ inline void TFProfObserver::Summary::dump_tsum(std::ostream& os) const {
 
   std::for_each(tsum.begin(), tsum.end(), [&](const auto& i){
     if(i.count == 0) return;
-    count_w = std::max(count_w, std::to_string(i.count).size());
+	count_w = (std::max)(count_w, std::to_string(i.count).size());
   });
   
   std::for_each(tsum.begin(), tsum.end(), [&](const auto& i){
     if(i.count == 0) return;
-    time_w = std::max(time_w, std::to_string(i.total_span).size());
+    time_w = (std::max)(time_w, std::to_string(i.total_span).size());
   });
   
   std::for_each(tsum.begin(), tsum.end(), [&](const auto& i){
     if(i.count == 0) return;
-    avg_w = std::max(time_w, std::to_string(i.avg_span()).size());
+    avg_w = (std::max)(time_w, std::to_string(i.avg_span()).size());
   });
   
   std::for_each(tsum.begin(), tsum.end(), [&](const auto& i){
     if(i.count == 0) return;
-    min_w = std::max(min_w, std::to_string(i.min_span).size());
+    min_w = (std::max)(min_w, std::to_string(i.min_span).size());
   });
   
   std::for_each(tsum.begin(), tsum.end(), [&](const auto& i){
     if(i.count == 0) return;
-    max_w = std::max(max_w, std::to_string(i.max_span).size());
+    max_w = (std::max)(max_w, std::to_string(i.max_span).size());
   });
 
   os << std::setw(type_w) << "-Task-" 
@@ -590,32 +590,32 @@ inline void TFProfObserver::Summary::dump_wsum(std::ostream& os) const {
 
   std::for_each(wsum.begin(), wsum.end(), [&](const auto& i){
     if(i.count == 0) return;
-    l_w = std::max(l_w, std::to_string(i.level).size());
+    l_w = (std::max)(l_w, std::to_string(i.level).size());
   });
   
   std::for_each(wsum.begin(), wsum.end(), [&](const auto& i){
     if(i.count == 0) return;
-    c_w = std::max(c_w, std::to_string(i.count).size());
+    c_w = (std::max)(c_w, std::to_string(i.count).size());
   });
   
   std::for_each(wsum.begin(), wsum.end(), [&](const auto& i){
     if(i.count == 0) return;
-    d_w = std::max(d_w, std::to_string(i.total_span).size());
+    d_w = (std::max)(d_w, std::to_string(i.total_span).size());
   });
   
   std::for_each(wsum.begin(), wsum.end(), [&](const auto& i){
     if(i.count == 0) return;
-    avg_w = std::max(avg_w, std::to_string(i.avg_span()).size());
+    avg_w = (std::max)(avg_w, std::to_string(i.avg_span()).size());
   });
   
   std::for_each(wsum.begin(), wsum.end(), [&](const auto& i){
     if(i.count == 0) return;
-    min_w = std::max(min_w, std::to_string(i.min_span).size());
+    min_w = (std::max)(min_w, std::to_string(i.min_span).size());
   });
   
   std::for_each(wsum.begin(), wsum.end(), [&](const auto& i){
     if(i.count == 0) return;
-    max_w = std::max(max_w, std::to_string(i.max_span).size());
+    max_w = (std::max)(max_w, std::to_string(i.max_span).size());
   });
   
   os << std::setw(w_w) << "-Worker-" 
@@ -840,8 +840,8 @@ inline void TFProfObserver::summary(std::ostream& os) const {
         
         // update the entire span
         auto& s = _timeline.segments[w][l][i];
-        view_beg = view_beg ? std::min(*view_beg, s.beg) : s.beg;
-        view_end = view_end ? std::max(*view_end, s.end) : s.end;
+        view_beg = view_beg ? (std::min)(*view_beg, s.beg) : s.beg;
+        view_end = view_end ? (std::max)(*view_end, s.end) : s.end;
         
         // update the task summary
         size_t t = duration_cast<microseconds>(s.end - s.beg).count();
@@ -849,19 +849,19 @@ inline void TFProfObserver::summary(std::ostream& os) const {
         auto& x = summary.tsum[static_cast<int>(s.type)];
         x.count += 1;
         x.total_span += t;
-        x.min_span = (x.count == 1) ? t : std::min(t, x.min_span);
-        x.max_span = (x.count == 1) ? t : std::max(t, x.max_span);
+        x.min_span = (x.count == 1) ? t : (std::min)(t, x.min_span);
+        x.max_span = (x.count == 1) ? t : (std::max)(t, x.max_span);
 
         // update the worker summary
         ws.total_span += t;
-        ws.min_span = (i == 0) ? t : std::min(t, ws.min_span);
-        ws.max_span = (i == 0) ? t : std::max(t, ws.max_span);
+        ws.min_span = (i == 0) ? t : (std::min)(t, ws.min_span);
+        ws.max_span = (i == 0) ? t : (std::max)(t, ws.max_span);
 
         auto&y = ws.tsum[static_cast<int>(s.type)];
         y.count += 1;
         y.total_span += t;
-        y.min_span = (y.count == 1) ? t : std::min(t, y.min_span);
-        y.max_span = (y.count == 1) ? t : std::max(t, y.max_span);
+        y.min_span = (y.count == 1) ? t : (std::min)(t, y.min_span);
+        y.max_span = (y.count == 1) ? t : (std::max)(t, y.max_span);
         
         // update the delay
         //if(i) {


### PR DESCRIPTION
This errors occur because the Windows` min `and `max` macros conflict with `std::min` and `std::max`. 