### PR TITLE
fix CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
 ## microsoft visual c++
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   add_definitions(/bigobj)
+  add_compile_options("/Zc:__cplusplus")
   if(NOT MSVC_VERSION GREATER_EQUAL 1914)
     message(STATUS "CMAKE_CXX_COMPILER_VERSION: ${CMAKE_CXX_COMPILER_VERSION}")
     message(FATAL_ERROR "\nTaskflow requires MSVC++ at least v14.14") 


### PR DESCRIPTION
The current code uses the **__cplusplus** macro to detect C++ versions, but MSVC does not update this macro by default (it remains **199711L**). This causes incorrect version detection in Visual Studio.

This PR adds **/Zc:__cplusplus** to CMake compile options for MSVC, ensuring __cplusplus reflects the actual C++ standard.