### PR TITLE
Commit Message: Fix variable naming conflict and update header depend…

### DIFF
--- a/taskflow/core/atomic_notifier.hpp
+++ b/taskflow/core/atomic_notifier.hpp
@@ -5,6 +5,8 @@
 #include <atomic>
 #include <thread>
 #include <vector>
+#include <assert.h>
+#include "../utility/os.hpp"
 
 namespace tf {
 


### PR DESCRIPTION
…encies

Description:
- Renamed the variable `signals` to `sigs` because `signals` is a keyword in the Qt signal-slot mechanism, which causes compilation errors in a Qt environment. The abbreviation `sigs` is used as a replacement to avoid conflicts.
- Used the macro `TF_CACHELINE_SIZE` in the file `nonblocking_notifier.hpp`, which defines the cache line size for optimizing memory alignment and performance.
- Added the header file `#include "../utility/os.hpp"` to provide operating system-related utility support, such as platform-specific definitions for cache line size.

Changed Files:
- `taskflow/core/nonblocking_notifier.hpp`