### PR TITLE
update compiler versions in docs and printouts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   add_compile_options("/Zc:__cplusplus")
   if(NOT MSVC_VERSION GREATER_EQUAL 1914)
     message(STATUS "CMAKE_CXX_COMPILER_VERSION: ${CMAKE_CXX_COMPILER_VERSION}")
-    message(FATAL_ERROR "\nTaskflow requires MSVC++ at least v14.14") 
+    message(FATAL_ERROR "\nTaskflow requires MSVC++ at least v19.14") 
   endif()
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
   if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.0.1")
@@ -83,10 +83,10 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
 else()
   message(FATAL_ERROR "\n\
 Taskflow currently supports the following compilers:\n\
-  - g++ v7.0 or above\n\
+  - g++ v8.4 or above\n\
   - clang++ v6.0 or above\n\
   - MSVC++ v19.14 or above\n\
-  - AppleClang v8 or above\n\
+  - AppleClang v12.0 or above\n\
   - Intel v19.0.1 or above\n\
 ")
 endif()

--- a/README.md
+++ b/README.md
@@ -377,8 +377,8 @@ To use Taskflow, you only need a compiler that supports C++17:
 
 Taskflow works on Linux, Windows, and Mac OS X.
 
-Although %Taskflow supports primarily C++17, you can enable C++20 compilation
-through `-std=c++20` to achieve better performance due to new C++20 features.
+Although Taskflow supports primarily C++17, you can enable C++20 compilation
+through `-std=c++20` (or `/std:c++20` for MSVC) to achieve better performance due to new C++20 features.
 
 # Learn More about Taskflow
 

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ To use Taskflow, you only need a compiler that supports C++17:
 
 + GNU C++ Compiler at least v8.4 with -std=c++17
 + Clang C++ Compiler at least v6.0 with -std=c++17
-+ Microsoft Visual Studio at least v19.27 with /std:c++17
++ Microsoft Visual Studio at least v19.14 with /std:c++17
 + AppleClang Xcode Version at least v12.0 with -std=c++17
 + Nvidia CUDA Toolkit and Compiler (nvcc) at least v11.1 with -std=c++17
 + Intel C++ Compiler at least v19.0.1 with -std=c++17

--- a/doxygen/QuickStart.dox
+++ b/doxygen/QuickStart.dox
@@ -305,7 +305,7 @@ To use %Taskflow, you only need a compiler that supports C++17:
 
 @attention
 Although %Taskflow supports primarily C++17, you can enable C++20 compilation
-through `-std=c++20` to achieve better performance due to new C++20 features.
+through `-std=c++20` (or `/std:c++20` for MSVC) to achieve better performance due to new C++20 features.
 
 @section QuickStartGetInvolved Get Involved
 

--- a/doxygen/QuickStart.dox
+++ b/doxygen/QuickStart.dox
@@ -295,7 +295,7 @@ To use %Taskflow, you only need a compiler that supports C++17:
 
 @li GNU C++ Compiler at least v8.4 with -std=c++17
 @li Clang C++ Compiler at least v6.0 with -std=c++17
-@li Microsoft Visual Studio at least v19.27 with /std:c++17
+@li Microsoft Visual Studio at least v19.14 with /std:c++17
 @li Apple Clang Xcode Version at least v12.0 with -std=c++17
 @li Nvidia CUDA Toolkit and Compiler (nvcc) at least v11.1 with -std=c++17
 @li Intel C++ Compiler at least v19.0.1 with -std=c++17

--- a/doxygen/install/install.dox
+++ b/doxygen/install/install.dox
@@ -16,7 +16,7 @@ To use %Taskflow, you only need a compiler that supports C++17:
 @li Microsoft Visual Studio at least v15.7 (MSVC++ 19.14)
 @li AppleClang Xcode Version at least v12.0 with -std=c++17
 @li Nvidia CUDA Toolkit and Compiler (nvcc) at least v11.1 with -std=c++17
-@li Intel C++ Compiler (nvcc) at least v19.0.1 with -std=c++17
+@li Intel C++ Compiler (icpc) at least v19.0.1 with -std=c++17
 @li Intel DPC++ Clang Compiler at least v13.0.0 with -std=c++17 and SYCL20
 
 %Taskflow works on Linux, Windows, and Mac OS X.


### PR DESCRIPTION
Updating the minimal compiler versions in cmake printouts and documentation. This is assuming the checks in cmake are still correct