### PR TITLE
Fix find_if and find_if_not to support infinite ranges

### DIFF
--- a/taskflow/algorithm/find.hpp
+++ b/taskflow/algorithm/find.hpp
@@ -20,6 +20,18 @@ auto make_find_if_task(B first, E last, T& result, UOP predicate, P part = P()) 
     E_t end = last;
 
     size_t W = rt.executor().num_workers();
+    
+    // Check if we can compute distance (finite range) or if we have a sentinel (infinite range)
+    // For sentinel-based ranges, we cannot compute distance and must use sequential execution
+    if constexpr (!std::is_same_v<E_t, B_t>) {
+      // Sentinel-based range (infinite range) - use sequential execution
+      part([=, &result]() mutable { 
+        result = std::find_if(beg, end, predicate); 
+      })();
+      return;
+    }
+    
+    // For finite ranges, compute distance and use parallel execution
     size_t N = std::distance(beg, end);
 
     // only myself - no need to spawn another graph
@@ -108,6 +120,18 @@ auto make_find_if_not_task(B first, E last, T& result, UOP predicate, P part = P
     E_t end = last;
 
     size_t W = rt.executor().num_workers();
+    
+    // Check if we can compute distance (finite range) or if we have a sentinel (infinite range)
+    // For sentinel-based ranges, we cannot compute distance and must use sequential execution
+    if constexpr (!std::is_same_v<E_t, B_t>) {
+      // Sentinel-based range (infinite range) - use sequential execution
+      part([=, &result]() mutable { 
+        result = std::find_if_not(beg, end, predicate); 
+      })();
+      return;
+    }
+    
+    // For finite ranges, compute distance and use parallel execution
     size_t N = std::distance(beg, end);
 
     // only myself - no need to spawn another graph


### PR DESCRIPTION
- Add compile-time detection for sentinel-based ranges
- Fall back to sequential execution for infinite ranges
- Maintain parallel execution for finite ranges
- Fixes issue #534: taskflow::find_if doesn't work with infinite ranges

The fix uses SFINAE to detect when E_t (end iterator type) differs from B_t (begin iterator type), indicating a sentinel-based range that cannot use std::distance.