### PR TITLE
Fix brace-init with explicit constructor for GCC 15

### DIFF
--- a/taskflow/core/wsq.hpp
+++ b/taskflow/core/wsq.hpp
@@ -156,7 +156,7 @@ class UnboundedWSQ {
     }
 
     Array* resize(int64_t b, int64_t t) {
-      Array* ptr = new Array {2*C};
+      Array* ptr = new Array(2*C);
       for(int64_t i=t; i!=b; ++i) {
         ptr->push(i, pop(i));
       }
@@ -165,7 +165,7 @@ class UnboundedWSQ {
 
     Array* resize(int64_t b, int64_t t, size_t N) {
       // assert(N>0);
-      Array* ptr = new Array {std::bit_ceil(C + N)};
+      Array* ptr = new Array(std::bit_ceil(C + N));
       for(int64_t i=t; i!=b; ++i) {
         ptr->push(i, pop(i));
       }


### PR DESCRIPTION
## Summary

GCC 15 rejects brace-initialization when the constructor is marked `explicit` ([GCC bug 119671](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=119671)). This causes a build failure in `UnboundedWSQ::Array::resize()`.

The fix switches from brace-init (`new Array {2*C}`) to parenthesized init (`new Array(2*C)`), which is always valid regardless of whether the constructor is explicit.

I encountered this bug when building [nixl](github.com/ai-dynamo/nixl) (which has taskflow as a dependency).

## Changes

- `taskflow/core/wsq.hpp`: Replace `new Array {…}` with `new Array(…)` in both `resize` overloads.