### PR TITLE
Add pkg-config support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,3 +374,13 @@ install(
         ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
   DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}
 )
+
+# -----------------------------------------------------------------------------
+# pkg-config
+# -----------------------------------------------------------------------------
+
+configure_file(taskflow.pc.in taskflow.pc @ONLY)
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/taskflow.pc
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+)

--- a/taskflow.pc.in
+++ b/taskflow.pc.in
@@ -1,0 +1,7 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: Taskflow
+Description: A General-purpose Task-parallel Programming System
+Version: @PROJECT_VERSION@
+Cflags: -I${includedir}


### PR DESCRIPTION
## Summary

Taskflow currently only provides CMake's `find_package` for discovery. This PR adds a `taskflow.pc` file so that downstream projects using pkg-config (or build systems like Meson that prefer it) can also discover Taskflow.

## Changes

- Add `taskflow.pc.in` template
- Add `configure_file` and `install` rules in `CMakeLists.txt` to generate and install `taskflow.pc` to `${CMAKE_INSTALL_LIBDIR}/pkgconfig`