### PR TITLE
perf(wsq): remove UnboundedWSQ::pop() and relax steal() ordering;

### DIFF
--- a/taskflow/core/wsq.hpp
+++ b/taskflow/core/wsq.hpp
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <bit>
 
@@ -294,28 +294,6 @@ class UnboundedWSQ {
   void bulk_push(I& first, size_t N);
 
   /**
-  @brief pops out an item from the queue
-
-  This method pops an item from the queue.
-  If the queue is empty, empty_value() is returned.
-  The elements popped out from the queue follow a last-in-first-out (LIFO) order.
-  
-  @code{.cpp}
-  tf::UnboundedWSQ<int> wsq(10);  
-  wsq.push(1);
-  wsq.push(2);
-  wsq.push(3);
-  assert(wsq.pop().value() = 3);
-  assert(wsq.pop().value() = 2);
-  assert(wsq.pop().value() = 1);
-  assert(wsq.pop() == std::nullopt);
-  @endcode
-  
-  Only the owner thread can pop out an item from the queue.
-  */
-  value_type pop();
-
-  /**
   @brief steals an item from the queue
 
   Any threads can try to steal an item from the queue.
@@ -440,46 +418,12 @@ void UnboundedWSQ<T>::bulk_push(I& first, size_t N) {
   _bottom.store(b, std::memory_order_release);
 }
 
-// Function: pop
-template <typename T>
-typename UnboundedWSQ<T>::value_type 
-UnboundedWSQ<T>::pop() {
-
-  int64_t b = _bottom.load(std::memory_order_relaxed) - 1;
-  Array* a = _array.load(std::memory_order_relaxed);
-  _bottom.store(b, std::memory_order_relaxed);
-  std::atomic_thread_fence(std::memory_order_seq_cst);
-  int64_t t = _top.load(std::memory_order_relaxed);
-
-  //T item {nullptr};
-  auto item = empty_value();
-
-  if(t <= b) {
-    item = a->pop(b);
-    if(t == b) {
-      // the last item just got stolen
-      if(!_top.compare_exchange_strong(t, t+1, std::memory_order_seq_cst,
-                                               std::memory_order_relaxed)) {
-        //item = nullptr;
-        item = empty_value();
-      }
-      _bottom.store(b + 1, std::memory_order_relaxed);
-    }
-  }
-  else {
-    _bottom.store(b + 1, std::memory_order_relaxed);
-  }
-
-  return item;
-}
-
 // Function: steal
 template <typename T>
 typename UnboundedWSQ<T>::value_type 
 UnboundedWSQ<T>::steal() {
   
-  int64_t t = _top.load(std::memory_order_acquire);
-  std::atomic_thread_fence(std::memory_order_seq_cst);
+  int64_t t = _top.load(std::memory_order_relaxed);
   int64_t b = _bottom.load(std::memory_order_acquire);
 
   //T item {nullptr};
@@ -489,7 +433,7 @@ UnboundedWSQ<T>::steal() {
     Array* a = _array.load(std::memory_order_consume);
     item = a->pop(t);
     if(!_top.compare_exchange_strong(t, t+1,
-                                     std::memory_order_seq_cst,
+                                     std::memory_order_acq_rel,
                                      std::memory_order_relaxed)) {
       //return nullptr;
       return empty_value();
@@ -833,8 +777,8 @@ BoundedWSQ<T, LogSize>::pop() {
     item = _buffer[b & BufferMask].load(std::memory_order_relaxed);
     if(t == b) {
       // the last item just got stolen
-      if(!_top.compare_exchange_strong(t, t+1, 
-                                       std::memory_order_seq_cst, 
+      if(!_top.compare_exchange_strong(t, t+1,
+                                       std::memory_order_acq_rel,
                                        std::memory_order_relaxed)) {
         //item = nullptr;
         item = empty_value();
@@ -853,7 +797,7 @@ BoundedWSQ<T, LogSize>::pop() {
 template <typename T, size_t LogSize>
 typename BoundedWSQ<T, LogSize>::value_type 
 BoundedWSQ<T, LogSize>::steal() {
-  int64_t t = _top.load(std::memory_order_acquire);
+  int64_t t = _top.load(std::memory_order_relaxed);
   std::atomic_thread_fence(std::memory_order_seq_cst);
   int64_t b = _bottom.load(std::memory_order_acquire);
   

--- a/unittests/test_wsq.cpp
+++ b/unittests/test_wsq.cpp
@@ -1,4 +1,4 @@
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+﻿#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 
 #include <doctest.h>
 #include <taskflow/taskflow.hpp>
@@ -15,80 +15,80 @@
 template<size_t LogSize>
 void bounded_wsq_owner() {
 
-  tf::BoundedWSQ<void*, LogSize> queue;
+    tf::BoundedWSQ<void*, LogSize> queue;
 
-  constexpr size_t N = (1 << LogSize);
+    constexpr size_t N = (1 << LogSize);
 
-  std::vector<void*> data(1);  // dummy space to avoid nullptr when calling .data
+    std::vector<void*> data(1);  // dummy space to avoid nullptr when calling .data
 
-  for(size_t k=0; k<LogSize*10; k++) {
+    for(size_t k=0; k<LogSize*10; k++) {
 
-    data.clear();
+        data.clear();
 
-    REQUIRE(queue.empty() == true);
+        REQUIRE(queue.empty() == true);
 
-    for(size_t i=0; i<N; i++) {
-      auto ptr = data.data() + i;
-      REQUIRE(queue.try_push(ptr) == true);
-      data.push_back(ptr);
+        for(size_t i=0; i<N; i++) {
+            auto ptr = data.data() + i;
+            REQUIRE(queue.try_push(ptr) == true);
+            data.push_back(ptr);
+        }
+        REQUIRE(queue.try_push(nullptr) == false);
+
+        for(size_t i=0; i<N; i++) {
+            auto item = queue.pop();
+            REQUIRE(item != nullptr);
+            REQUIRE(item == data[N-i-1]);
+        }
+
+        for(size_t i=0; i<N; i++) {
+            REQUIRE(queue.pop() == nullptr);
+        }
     }
-    REQUIRE(queue.try_push(nullptr) == false);
 
-    for(size_t i=0; i<N; i++) {
-      auto item = queue.pop();
-      REQUIRE(item != nullptr);
-      REQUIRE(item == data[N-i-1]);
-    }
+    // test steal (plain, two-state)
+    size_t dummy1, dummy2;
 
-    for(size_t i=0; i<N; i++) {
-      REQUIRE(queue.pop() == nullptr);
-    }
-  }
-
-  // test steal (plain, two-state)
-  size_t dummy1, dummy2;
-
-  REQUIRE(queue.try_push(&dummy1) == true);
-  REQUIRE(queue.try_push(&dummy2) == true);
-  REQUIRE(queue.steal() == &dummy1);
-  REQUIRE(queue.steal() == &dummy2);
-  REQUIRE(queue.steal() == nullptr);
+    REQUIRE(queue.try_push(&dummy1) == true);
+    REQUIRE(queue.try_push(&dummy2) == true);
+    REQUIRE(queue.steal() == &dummy1);
+    REQUIRE(queue.steal() == &dummy2);
+    REQUIRE(queue.steal() == nullptr);
 }
 
 TEST_CASE("BoundedWSQ.Owner.LogSize=2" * doctest::timeout(300)) {
-  bounded_wsq_owner<2>();
+    bounded_wsq_owner<2>();
 }
 
 TEST_CASE("BoundedWSQ.Owner.LogSize=3" * doctest::timeout(300)) {
-  bounded_wsq_owner<3>();
+    bounded_wsq_owner<3>();
 }
 
 TEST_CASE("BoundedWSQ.Owner.LogSize=4" * doctest::timeout(300)) {
-  bounded_wsq_owner<4>();
+    bounded_wsq_owner<4>();
 }
 
 TEST_CASE("BoundedWSQ.Owner.LogSize=5" * doctest::timeout(300)) {
-  bounded_wsq_owner<5>();
+    bounded_wsq_owner<5>();
 }
 
 TEST_CASE("BoundedWSQ.Owner.LogSize=6" * doctest::timeout(300)) {
-  bounded_wsq_owner<6>();
+    bounded_wsq_owner<6>();
 }
 
 TEST_CASE("BoundedWSQ.Owner.LogSize=7" * doctest::timeout(300)) {
-  bounded_wsq_owner<7>();
+    bounded_wsq_owner<7>();
 }
 
 TEST_CASE("BoundedWSQ.Owner.LogSize=8" * doctest::timeout(300)) {
-  bounded_wsq_owner<8>();
+    bounded_wsq_owner<8>();
 }
 
 TEST_CASE("BoundedWSQ.Owner.LogSize=9" * doctest::timeout(300)) {
-  bounded_wsq_owner<9>();
+    bounded_wsq_owner<9>();
 }
 
 TEST_CASE("BoundedWSQ.Owner.LogSize=10" * doctest::timeout(300)) {
-  bounded_wsq_owner<10>();
+    bounded_wsq_owner<10>();
 }
 
 
@@ -98,43 +98,43 @@ TEST_CASE("BoundedWSQ.Owner.LogSize=10" * doctest::timeout(300)) {
 // ----------------------------------------------------------------------------
 
 TEST_CASE("BoundedWSQ.ValueType") {
-  tf::BoundedWSQ<void*> Q1;
-  tf::BoundedWSQ<int>   Q2;
+    tf::BoundedWSQ<void*> Q1;
+    tf::BoundedWSQ<int>   Q2;
 
-  // empty_value(): nullptr for pointer types, nullopt for non-pointer
-  auto empty1 = Q1.empty_value();
-  auto empty2 = Q2.empty_value();
+    // empty_value(): nullptr for pointer types, nullopt for non-pointer
+    auto empty1 = Q1.empty_value();
+    auto empty2 = Q2.empty_value();
 
-  static_assert(std::is_same_v<decltype(empty1), void*>);
-  static_assert(std::is_same_v<decltype(empty2), std::optional<int>>);
+    static_assert(std::is_same_v<decltype(empty1), void*>);
+    static_assert(std::is_same_v<decltype(empty2), std::optional<int>>);
 
-  REQUIRE(empty1 == nullptr);
-  REQUIRE(empty2 == std::nullopt);
+    REQUIRE(empty1 == nullptr);
+    REQUIRE(empty2 == std::nullopt);
 
-  // push/pop/steal still work normally
-  auto v = Q2.pop();
-  REQUIRE(v == std::nullopt);
+    // push/pop/steal still work normally
+    auto v = Q2.pop();
+    REQUIRE(v == std::nullopt);
 
-  Q2.try_push(1);
-  Q2.try_push(2);
-  Q2.try_push(3);
-  Q2.try_push(4);
+    Q2.try_push(1);
+    Q2.try_push(2);
+    Q2.try_push(3);
+    Q2.try_push(4);
 
-  REQUIRE(Q2.pop()   == 4);
-  REQUIRE(Q2.pop()   == 3);
-  REQUIRE(Q2.pop()   == 2);
-  REQUIRE(Q2.pop()   == 1);
-  REQUIRE(Q2.pop()   == std::nullopt);
+    REQUIRE(Q2.pop()   == 4);
+    REQUIRE(Q2.pop()   == 3);
+    REQUIRE(Q2.pop()   == 2);
+    REQUIRE(Q2.pop()   == 1);
+    REQUIRE(Q2.pop()   == std::nullopt);
 
-  Q2.try_push(1);
-  Q2.try_push(2);
-  Q2.try_push(3);
-  Q2.try_push(4);
-  REQUIRE(Q2.steal() == 1);
-  REQUIRE(Q2.steal() == 2);
-  REQUIRE(Q2.steal() == 3);
-  REQUIRE(Q2.steal() == 4);
-  REQUIRE(Q2.steal() == std::nullopt);
+    Q2.try_push(1);
+    Q2.try_push(2);
+    Q2.try_push(3);
+    Q2.try_push(4);
+    REQUIRE(Q2.steal() == 1);
+    REQUIRE(Q2.steal() == 2);
+    REQUIRE(Q2.steal() == 3);
+    REQUIRE(Q2.steal() == 4);
+    REQUIRE(Q2.steal() == std::nullopt);
 }
 
 // ----------------------------------------------------------------------------
@@ -143,98 +143,98 @@ TEST_CASE("BoundedWSQ.ValueType") {
 
 void bounded_wsq_n_consumers(size_t M) {
 
-  tf::BoundedWSQ<void*> queue;
+    tf::BoundedWSQ<void*> queue;
 
-  std::vector<void*> gold;
-  std::atomic<size_t> consumed;
+    std::vector<void*> gold;
+    std::atomic<size_t> consumed;
 
-  // 1, 4, 13, 40, 121, 364, 1093, 3280, 9841, 29524, 88573
-  for(size_t N=1; N<=88573; N=N*3+1) {
+    // 1, 4, 13, 40, 121, 364, 1093, 3280, 9841, 29524, 88573
+    for(size_t N=1; N<=88573; N=N*3+1) {
 
-    REQUIRE(queue.empty());
+        REQUIRE(queue.empty());
 
-    gold.resize(N);
-    consumed = 0;
+        gold.resize(N);
+        consumed = 0;
 
-    for(size_t i=0; i<N; ++i) {
-      gold[i] = gold.data() + i;
-    }
+        for(size_t i=0; i<N; ++i) {
+            gold[i] = gold.data() + i;
+        }
 
-    std::vector<std::thread> threads;
-    std::vector<std::vector<void*>> stolens(M);
+        std::vector<std::thread> threads;
+        std::vector<std::vector<void*>> stolens(M);
 
-    for(size_t i=0; i<M; ++i) {
-      threads.emplace_back([&, i](){
+        for(size_t i=0; i<M; ++i) {
+            threads.emplace_back([&, i](){
+                while(consumed != N) {
+                    auto ptr = queue.steal();
+                    if(ptr != nullptr) {
+                        stolens[i].push_back(ptr);
+                        consumed.fetch_add(1, std::memory_order_relaxed);
+                    }
+                }
+                REQUIRE(queue.steal() == nullptr);
+            });
+        }
+
+        for(size_t i=0; i<N; ++i) {
+            while(queue.try_push(gold[i]) == false);
+        }
+
+        std::vector<void*> items;
         while(consumed != N) {
-          auto ptr = queue.steal();
-          if(ptr != nullptr) {
-            stolens[i].push_back(ptr);
-            consumed.fetch_add(1, std::memory_order_relaxed);
-          }
+            auto ptr = queue.pop();
+            if(ptr != nullptr) {
+                items.push_back(ptr);
+                consumed.fetch_add(1, std::memory_order_relaxed);
+            }
         }
         REQUIRE(queue.steal() == nullptr);
-      });
+        REQUIRE(queue.pop()   == nullptr);
+        REQUIRE(queue.empty());
+
+        for(auto& thread : threads) thread.join();
+
+        for(size_t i=0; i<M; ++i) {
+            for(auto s : stolens[i]) items.push_back(s);
+        }
+
+        std::sort(items.begin(), items.end());
+        std::sort(gold.begin(),  gold.end());
+        REQUIRE(items.size() == N);
+        REQUIRE(items == gold);
     }
-
-    for(size_t i=0; i<N; ++i) {
-      while(queue.try_push(gold[i]) == false);
-    }
-
-    std::vector<void*> items;
-    while(consumed != N) {
-      auto ptr = queue.pop();
-      if(ptr != nullptr) {
-        items.push_back(ptr);
-        consumed.fetch_add(1, std::memory_order_relaxed);
-      }
-    }
-    REQUIRE(queue.steal() == nullptr);
-    REQUIRE(queue.pop()   == nullptr);
-    REQUIRE(queue.empty());
-
-    for(auto& thread : threads) thread.join();
-
-    for(size_t i=0; i<M; ++i) {
-      for(auto s : stolens[i]) items.push_back(s);
-    }
-
-    std::sort(items.begin(), items.end());
-    std::sort(gold.begin(),  gold.end());
-    REQUIRE(items.size() == N);
-    REQUIRE(items == gold);
-  }
 }
 
 TEST_CASE("BoundedWSQ.1Consumer" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers(1);
+    bounded_wsq_n_consumers(1);
 }
 
 TEST_CASE("BoundedWSQ.2Consumers" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers(2);
+    bounded_wsq_n_consumers(2);
 }
 
 TEST_CASE("BoundedWSQ.3Consumers" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers(3);
+    bounded_wsq_n_consumers(3);
 }
 
 TEST_CASE("BoundedWSQ.4Consumers" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers(4);
+    bounded_wsq_n_consumers(4);
 }
 
 TEST_CASE("BoundedWSQ.5Consumers" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers(5);
+    bounded_wsq_n_consumers(5);
 }
 
 TEST_CASE("BoundedWSQ.6Consumers" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers(6);
+    bounded_wsq_n_consumers(6);
 }
 
 TEST_CASE("BoundedWSQ.7Consumers" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers(7);
+    bounded_wsq_n_consumers(7);
 }
 
 TEST_CASE("BoundedWSQ.8Consumers" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers(8);
+    bounded_wsq_n_consumers(8);
 }
 
 // ----------------------------------------------------------------------------
@@ -243,217 +243,209 @@ TEST_CASE("BoundedWSQ.8Consumers" * doctest::timeout(300)) {
 
 void bounded_wsq_n_consumers_bulk_push(size_t M) {
 
-  tf::BoundedWSQ<void*> queue;
+    tf::BoundedWSQ<void*> queue;
 
-  std::vector<void*> gold;
-  std::atomic<size_t> consumed;
+    std::vector<void*> gold;
+    std::atomic<size_t> consumed;
 
-  // 1, 4, 13, 40, 121, 364, 1093, 3280, 9841, 29524, 88573
-  for(size_t N=1; N<=88573; N=N*3+1) {
+    // 1, 4, 13, 40, 121, 364, 1093, 3280, 9841, 29524, 88573
+    for(size_t N=1; N<=88573; N=N*3+1) {
 
-    REQUIRE(queue.empty());
+        REQUIRE(queue.empty());
 
-    gold.resize(N);
-    consumed = 0;
+        gold.resize(N);
+        consumed = 0;
 
-    for(size_t i=0; i<N; ++i) {
-      gold[i] = gold.data() + i;
-    }
+        for(size_t i=0; i<N; ++i) {
+            gold[i] = gold.data() + i;
+        }
 
-    size_t capacity = queue.capacity();
-    const size_t num_pushable = std::min(capacity, N);
+        size_t capacity = queue.capacity();
+        const size_t num_pushable = std::min(capacity, N);
 
-    // bulk push and pop
-    auto first = gold.data();
-    REQUIRE(num_pushable == queue.try_bulk_push(first, N));
-    REQUIRE(queue.size() == num_pushable);
-    for(size_t i=0; i<num_pushable; i++) {
-      REQUIRE(queue.pop() == gold[num_pushable - i - 1]);
-    }
-    REQUIRE(queue.empty() == true);
+        // bulk push and pop
+        auto first = gold.data();
+        REQUIRE(num_pushable == queue.try_bulk_push(first, N));
+        REQUIRE(queue.size() == num_pushable);
+        for(size_t i=0; i<num_pushable; i++) {
+            REQUIRE(queue.pop() == gold[num_pushable - i - 1]);
+        }
+        REQUIRE(queue.empty() == true);
 
-    // bulk push and steal
-    first = gold.data();
-    REQUIRE(num_pushable == queue.try_bulk_push(first, N));
-    REQUIRE(queue.size() == num_pushable);
-    for(size_t i=0; i<num_pushable; i++) {
-      REQUIRE(queue.steal() == gold[i]);
-    }
-    REQUIRE(queue.empty() == true);
+        // bulk push and steal
+        first = gold.data();
+        REQUIRE(num_pushable == queue.try_bulk_push(first, N));
+        REQUIRE(queue.size() == num_pushable);
+        for(size_t i=0; i<num_pushable; i++) {
+            REQUIRE(queue.steal() == gold[i]);
+        }
+        REQUIRE(queue.empty() == true);
 
-    // concurrent bulk push + thieves
-    std::vector<std::thread> threads;
-    std::vector<std::vector<void*>> stolens(M);
+        // concurrent bulk push + thieves
+        std::vector<std::thread> threads;
+        std::vector<std::vector<void*>> stolens(M);
 
-    for(size_t i=0; i<M; ++i) {
-      threads.emplace_back([&, i](){
+        for(size_t i=0; i<M; ++i) {
+            threads.emplace_back([&, i](){
+                while(consumed != N) {
+                    auto ptr = queue.steal();
+                    if(ptr != nullptr) {
+                        stolens[i].push_back(ptr);
+                        consumed.fetch_add(1, std::memory_order_relaxed);
+                    }
+                }
+                REQUIRE(queue.steal() == nullptr);
+            });
+        }
+
+        first = gold.data();
+        for(size_t n=0; n<N;) {
+            n += queue.try_bulk_push(first, N-n);
+        }
+
+        std::vector<void*> items;
         while(consumed != N) {
-          auto ptr = queue.steal();
-          if(ptr != nullptr) {
-            stolens[i].push_back(ptr);
-            consumed.fetch_add(1, std::memory_order_relaxed);
-          }
+            auto ptr = queue.pop();
+            if(ptr != nullptr) {
+                items.push_back(ptr);
+                consumed.fetch_add(1, std::memory_order_relaxed);
+            }
         }
         REQUIRE(queue.steal() == nullptr);
-      });
+        REQUIRE(queue.pop()   == nullptr);
+        REQUIRE(queue.empty());
+
+        for(auto& thread : threads) thread.join();
+
+        for(size_t i=0; i<M; ++i) {
+            for(auto s : stolens[i]) items.push_back(s);
+        }
+
+        std::sort(items.begin(), items.end());
+        std::sort(gold.begin(),  gold.end());
+        REQUIRE(items.size() == N);
+        REQUIRE(items == gold);
     }
-
-    first = gold.data();
-    for(size_t n=0; n<N;) {
-      n += queue.try_bulk_push(first, N-n);
-    }
-
-    std::vector<void*> items;
-    while(consumed != N) {
-      auto ptr = queue.pop();
-      if(ptr != nullptr) {
-        items.push_back(ptr);
-        consumed.fetch_add(1, std::memory_order_relaxed);
-      }
-    }
-    REQUIRE(queue.steal() == nullptr);
-    REQUIRE(queue.pop()   == nullptr);
-    REQUIRE(queue.empty());
-
-    for(auto& thread : threads) thread.join();
-
-    for(size_t i=0; i<M; ++i) {
-      for(auto s : stolens[i]) items.push_back(s);
-    }
-
-    std::sort(items.begin(), items.end());
-    std::sort(gold.begin(),  gold.end());
-    REQUIRE(items.size() == N);
-    REQUIRE(items == gold);
-  }
 }
 
 TEST_CASE("BoundedWSQ.1Consumer.BulkPush" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers_bulk_push(1);
+    bounded_wsq_n_consumers_bulk_push(1);
 }
 
 TEST_CASE("BoundedWSQ.2Consumers.BulkPush" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers_bulk_push(2);
+    bounded_wsq_n_consumers_bulk_push(2);
 }
 
 TEST_CASE("BoundedWSQ.3Consumers.BulkPush" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers_bulk_push(3);
+    bounded_wsq_n_consumers_bulk_push(3);
 }
 
 TEST_CASE("BoundedWSQ.4Consumers.BulkPush" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers_bulk_push(4);
+    bounded_wsq_n_consumers_bulk_push(4);
 }
 
 TEST_CASE("BoundedWSQ.5Consumers.BulkPush" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers_bulk_push(5);
+    bounded_wsq_n_consumers_bulk_push(5);
 }
 
 TEST_CASE("BoundedWSQ.6Consumers.BulkPush" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers_bulk_push(6);
+    bounded_wsq_n_consumers_bulk_push(6);
 }
 
 TEST_CASE("BoundedWSQ.7Consumers.BulkPush" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers_bulk_push(7);
+    bounded_wsq_n_consumers_bulk_push(7);
 }
 
 TEST_CASE("BoundedWSQ.8Consumers.BulkPush" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers_bulk_push(8);
+    bounded_wsq_n_consumers_bulk_push(8);
 }
 
 
 // ============================================================================
-// UnboundedWSQ Tests
+// UnboundedWSQ Tests  (steal-only: pop() has been removed)
 // ============================================================================
 
 TEST_CASE("UnboundedWSQ.Resize") {
-  tf::UnboundedWSQ<void*> queue(1);
-  REQUIRE(queue.capacity() == 2);
+    tf::UnboundedWSQ<void*> queue(1);
+    REQUIRE(queue.capacity() == 2);
 
-  std::vector<void*> data(2048);
+    std::vector<void*> data(2048);
 
-  auto first = data.data();
-  queue.bulk_push(first, 1);
-  REQUIRE(queue.size()     == 1);
-  REQUIRE(queue.capacity() == 2);
+    auto first = data.data();
+    queue.bulk_push(first, 1);
+    REQUIRE(queue.size()     == 1);
+    REQUIRE(queue.capacity() == 2);
 
-  first = data.data();
-  queue.bulk_push(first, 2);
-  REQUIRE(queue.size()     == 3);
-  REQUIRE(queue.capacity() == 4);
+    first = data.data();
+    queue.bulk_push(first, 2);
+    REQUIRE(queue.size()     == 3);
+    REQUIRE(queue.capacity() == 4);
 
-  first = data.data();
-  queue.bulk_push(first, 10);
-  REQUIRE(queue.size()     == 13);
-  REQUIRE(queue.capacity() == 16);
+    first = data.data();
+    queue.bulk_push(first, 10);
+    REQUIRE(queue.size()     == 13);
+    REQUIRE(queue.capacity() == 16);
 
-  first = data.data();
-  queue.bulk_push(first, 1200);
-  REQUIRE(queue.size()     == 1213);
-  REQUIRE(queue.capacity() == 2048);
+    first = data.data();
+    queue.bulk_push(first, 1200);
+    REQUIRE(queue.size()     == 1213);
+    REQUIRE(queue.capacity() == 2048);
 
-  for(size_t i=0; i<1213; ++i) {
-    REQUIRE(queue.size() == 1213 - i);
-    queue.pop();
-  }
-  REQUIRE(queue.empty() == true);
+    for(size_t i=0; i<1213; ++i) {
+        REQUIRE(queue.size() == 1213 - i);
+        queue.steal();
+    }
+    REQUIRE(queue.empty() == true);
 
-  // capacity does not shrink after drain
-  first = data.data();
-  queue.bulk_push(first, 1);
-  REQUIRE(queue.size()     == 1);
-  REQUIRE(queue.capacity() == 2048);
+    // capacity does not shrink after drain
+    first = data.data();
+    queue.bulk_push(first, 1);
+    REQUIRE(queue.size()     == 1);
+    REQUIRE(queue.capacity() == 2048);
 
-  first = data.data();
-  queue.bulk_push(first, 2);
-  REQUIRE(queue.size()     == 3);
-  REQUIRE(queue.capacity() == 2048);
+    first = data.data();
+    queue.bulk_push(first, 2);
+    REQUIRE(queue.size()     == 3);
+    REQUIRE(queue.capacity() == 2048);
 
-  first = data.data();
-  queue.bulk_push(first, 10);
-  REQUIRE(queue.size()     == 13);
-  REQUIRE(queue.capacity() == 2048);
+    first = data.data();
+    queue.bulk_push(first, 10);
+    REQUIRE(queue.size()     == 13);
+    REQUIRE(queue.capacity() == 2048);
 
-  first = data.data();
-  queue.bulk_push(first, 1200);
-  REQUIRE(queue.size()     == 1213);
-  REQUIRE(queue.capacity() == 2048);
+    first = data.data();
+    queue.bulk_push(first, 1200);
+    REQUIRE(queue.size()     == 1213);
+    REQUIRE(queue.capacity() == 2048);
 }
 
 // Procedure: unbounded_wsq_owner
+// steal-only: push N then verify FIFO drain via steal.
 void unbounded_wsq_owner() {
 
-  tf::UnboundedWSQ<void*> queue;
-  std::vector<void*> gold;
+    tf::UnboundedWSQ<void*> queue;
+    std::vector<void*> gold;
 
-  for(size_t N=1; N<=777777; N=N*2+1) {
+    for(size_t N=1; N<=777777; N=N*2+1) {
 
-    gold.resize(N);
-    REQUIRE(queue.empty());
+        gold.resize(N);
+        REQUIRE(queue.empty());
 
-    for(size_t i=0; i<N; ++i) {
-      gold[i] = gold.data() + i;
-      queue.push(gold[i]);
+        for(size_t i=0; i<N; ++i) {
+            gold[i] = gold.data() + i;
+            queue.push(gold[i]);
+        }
+        for(size_t i=0; i<N; ++i) {
+            auto ptr = queue.steal();
+            REQUIRE(ptr != nullptr);
+            REQUIRE(gold[i] == ptr);
+        }
+        REQUIRE(queue.steal() == nullptr);
     }
-    for(size_t i=0; i<N; ++i) {
-      auto ptr = queue.pop();
-      REQUIRE(ptr != nullptr);
-      REQUIRE(gold[N-i-1] == ptr);
-    }
-    REQUIRE(queue.pop() == nullptr);
-
-    for(size_t i=0; i<N; ++i) {
-      queue.push(gold[i]);
-    }
-    for(size_t i=0; i<N; ++i) {
-      auto ptr = queue.steal();
-      REQUIRE(ptr != nullptr);
-      REQUIRE(gold[i] == ptr);
-    }
-  }
 }
 
 TEST_CASE("UnboundedWSQ.Owner" * doctest::timeout(300)) {
-  unbounded_wsq_owner();
+    unbounded_wsq_owner();
 }
 
 
@@ -464,278 +456,240 @@ TEST_CASE("UnboundedWSQ.Owner" * doctest::timeout(300)) {
 
 TEST_CASE("UnboundedWSQ.ValueType") {
 
-  tf::UnboundedWSQ<void*> Q1;
-  tf::UnboundedWSQ<int>   Q2;
+    tf::UnboundedWSQ<void*> Q1;
+    tf::UnboundedWSQ<int>   Q2;
 
-  auto empty1 = Q1.empty_value();
-  auto empty2 = Q2.empty_value();
+    auto empty1 = Q1.empty_value();
+    auto empty2 = Q2.empty_value();
 
-  static_assert(std::is_same_v<decltype(empty1), void*>);
-  static_assert(std::is_same_v<decltype(empty2), std::optional<int>>);
+    static_assert(std::is_same_v<decltype(empty1), void*>);
+    static_assert(std::is_same_v<decltype(empty2), std::optional<int>>);
 
-  REQUIRE(empty1 == nullptr);
-  REQUIRE(empty2 == std::nullopt);
+    REQUIRE(empty1 == nullptr);
+    REQUIRE(empty2 == std::nullopt);
 
-  auto v = Q2.pop();
-  REQUIRE(v == std::nullopt);
+    auto v = Q2.steal();
+    REQUIRE(v == std::nullopt);
 
-  Q2.push(1);
-  Q2.push(2);
-  Q2.push(3);
-  Q2.push(4);
-
-  REQUIRE(Q2.pop()   == 4);
-  REQUIRE(Q2.pop()   == 3);
-  REQUIRE(Q2.pop()   == 2);
-  REQUIRE(Q2.pop()   == 1);
-  REQUIRE(Q2.pop()   == std::nullopt);
-
-  Q2.push(1);
-  Q2.push(2);
-  Q2.push(3);
-  Q2.push(4);
-  REQUIRE(Q2.steal() == 1);
-  REQUIRE(Q2.steal() == 2);
-  REQUIRE(Q2.steal() == 3);
-  REQUIRE(Q2.steal() == 4);
-  REQUIRE(Q2.steal() == std::nullopt);
+    Q2.push(1);
+    Q2.push(2);
+    Q2.push(3);
+    Q2.push(4);
+    REQUIRE(Q2.steal() == 1);
+    REQUIRE(Q2.steal() == 2);
+    REQUIRE(Q2.steal() == 3);
+    REQUIRE(Q2.steal() == 4);
+    REQUIRE(Q2.steal() == std::nullopt);
 }
 
 // ----------------------------------------------------------------------------
-// UnboundedWSQ Multiple Consumers Test (original, using plain steal)
+// UnboundedWSQ Multiple Consumers Test (steal-only)
 // ----------------------------------------------------------------------------
 
 void unbounded_wsq_n_consumers(size_t M) {
 
-  tf::UnboundedWSQ<void*> queue;
+    tf::UnboundedWSQ<void*> queue;
 
-  std::vector<void*> gold;
-  std::atomic<size_t> consumed;
+    std::vector<void*> gold;
+    std::atomic<size_t> consumed;
 
-  // 1, 4, 13, 40, 121, 364, 1093, 3280, 9841, 29524, 88573, 265720
-  for(size_t N=1; N<=265720; N=N*3+1) {
+    // 1, 4, 13, 40, 121, 364, 1093, 3280, 9841, 29524, 88573, 265720
+    for(size_t N=1; N<=265720; N=N*3+1) {
 
-    REQUIRE(queue.empty());
+        REQUIRE(queue.empty());
 
-    gold.resize(N);
-    consumed = 0;
+        gold.resize(N);
+        consumed = 0;
 
-    for(size_t i=0; i<N; ++i) {
-      gold[i] = gold.data() + i;
-    }
+        for(size_t i=0; i<N; ++i) {
+            gold[i] = gold.data() + i;
+        }
 
-    // master push and pop
-    for(size_t i=0; i<N; ++i) {
-      queue.push(gold.data() + i);
-    }
-    REQUIRE(queue.size() == N);
-    for(size_t i=0; i<N; i++) {
-      REQUIRE(queue.pop() == gold[N - i - 1]);
-    }
-    REQUIRE(queue.empty() == true);
+        // master push and steal (single-thread FIFO check)
+        for(size_t i=0; i<N; ++i) {
+            queue.push(gold.data() + i);
+        }
+        REQUIRE(queue.size() == N);
+        for(size_t i=0; i<N; i++) {
+            REQUIRE(queue.steal() == gold[i]);
+        }
+        REQUIRE(queue.empty() == true);
 
-    // master push and steal
-    for(size_t i=0; i<N; ++i) {
-      queue.push(gold.data() + i);
-    }
-    REQUIRE(queue.size() == N);
-    for(size_t i=0; i<N; i++) {
-      REQUIRE(queue.steal() == gold[i]);
-    }
-    REQUIRE(queue.empty() == true);
+        // concurrent: owner only pushes, all consumption done by thieves
+        std::vector<std::thread> threads;
+        std::vector<std::vector<void*>> stolens(M);
 
-    // concurrent
-    std::vector<std::thread> threads;
-    std::vector<std::vector<void*>> stolens(M);
+        for(size_t i=0; i<M; ++i) {
+            threads.emplace_back([&, i](){
+                while(consumed != N) {
+                    auto ptr = queue.steal();
+                    if(ptr != nullptr) {
+                        stolens[i].push_back(ptr);
+                        consumed.fetch_add(1, std::memory_order_relaxed);
+                    }
+                }
+                REQUIRE(queue.steal() == nullptr);
+            });
+        }
 
-    for(size_t i=0; i<M; ++i) {
-      threads.emplace_back([&, i](){
+        for(size_t i=0; i<N; ++i) {
+            queue.push(gold[i]);
+        }
+
+        // owner waits for thieves to drain (steal-only: owner cannot pop)
         while(consumed != N) {
-          auto ptr = queue.steal();
-          if(ptr != nullptr) {
-            stolens[i].push_back(ptr);
-            consumed.fetch_add(1, std::memory_order_relaxed);
-          }
+            std::this_thread::yield();
         }
         REQUIRE(queue.steal() == nullptr);
-      });
+        REQUIRE(queue.empty());
+
+        for(auto& thread : threads) thread.join();
+
+        std::vector<void*> items;
+        for(size_t i=0; i<M; ++i) {
+            for(auto s : stolens[i]) items.push_back(s);
+        }
+
+        std::sort(items.begin(), items.end());
+        std::sort(gold.begin(),  gold.end());
+        REQUIRE(items.size() == N);
+        REQUIRE(items == gold);
     }
-
-    for(size_t i=0; i<N; ++i) {
-      queue.push(gold[i]);
-    }
-
-    std::vector<void*> items;
-    while(consumed != N) {
-      auto ptr = queue.pop();
-      if(ptr != nullptr) {
-        items.push_back(ptr);
-        consumed.fetch_add(1, std::memory_order_relaxed);
-      }
-    }
-    REQUIRE(queue.steal() == nullptr);
-    REQUIRE(queue.pop()   == nullptr);
-    REQUIRE(queue.empty());
-
-    for(auto& thread : threads) thread.join();
-
-    for(size_t i=0; i<M; ++i) {
-      for(auto s : stolens[i]) items.push_back(s);
-    }
-
-    std::sort(items.begin(), items.end());
-    std::sort(gold.begin(),  gold.end());
-    REQUIRE(items.size() == N);
-    REQUIRE(items == gold);
-  }
 }
 
 TEST_CASE("UnboundedWSQ.1Consumer" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers(1);
+    unbounded_wsq_n_consumers(1);
 }
 
 TEST_CASE("UnboundedWSQ.2Consumers" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers(2);
+    unbounded_wsq_n_consumers(2);
 }
 
 TEST_CASE("UnboundedWSQ.3Consumers" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers(3);
+    unbounded_wsq_n_consumers(3);
 }
 
 TEST_CASE("UnboundedWSQ.4Consumers" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers(4);
+    unbounded_wsq_n_consumers(4);
 }
 
 TEST_CASE("UnboundedWSQ.5Consumers" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers(5);
+    unbounded_wsq_n_consumers(5);
 }
 
 TEST_CASE("UnboundedWSQ.6Consumers" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers(6);
+    unbounded_wsq_n_consumers(6);
 }
 
 TEST_CASE("UnboundedWSQ.7Consumers" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers(7);
+    unbounded_wsq_n_consumers(7);
 }
 
 TEST_CASE("UnboundedWSQ.8Consumers" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers(8);
+    unbounded_wsq_n_consumers(8);
 }
 
 // ----------------------------------------------------------------------------
-// UnboundedWSQ Multiple Consumers BulkPush Test
+// UnboundedWSQ Multiple Consumers BulkPush Test (steal-only)
 // ----------------------------------------------------------------------------
 
 void unbounded_wsq_n_consumers_bulk_push(size_t M) {
 
-  tf::UnboundedWSQ<void*> queue;
+    tf::UnboundedWSQ<void*> queue;
 
-  std::vector<void*> gold;
-  std::atomic<size_t> consumed;
+    std::vector<void*> gold;
+    std::atomic<size_t> consumed;
 
-  // 1, 4, 13, 40, 121, 364, 1093, 3280, 9841, 29524, 88573, 265720
-  for(size_t N=1; N<=265720; N=N*3+1) {
+    // 1, 4, 13, 40, 121, 364, 1093, 3280, 9841, 29524, 88573, 265720
+    for(size_t N=1; N<=265720; N=N*3+1) {
 
-    REQUIRE(queue.empty());
+        REQUIRE(queue.empty());
 
-    gold.resize(N);
-    consumed = 0;
+        gold.resize(N);
+        consumed = 0;
 
-    for(size_t i=0; i<N; ++i) {
-      gold[i] = gold.data() + i;
-    }
+        for(size_t i=0; i<N; ++i) {
+            gold[i] = gold.data() + i;
+        }
 
-    // bulk push and pop
-    auto first = gold.data();
-    queue.bulk_push(first, N);
-    REQUIRE(queue.size() == N);
-    for(size_t i=0; i<N; i++) {
-      REQUIRE(queue.pop() == gold[N - i - 1]);
-    }
-    REQUIRE(queue.empty() == true);
+        // bulk push and steal (single-thread FIFO check)
+        auto first = gold.data();
+        queue.bulk_push(first, N);
+        REQUIRE(queue.size() == N);
+        for(size_t i=0; i<N; i++) {
+            REQUIRE(queue.steal() == gold[i]);
+        }
+        REQUIRE(queue.empty() == true);
 
-    // bulk push and steal
-    first = gold.data();
-    queue.bulk_push(first, N);
-    REQUIRE(queue.size() == N);
-    for(size_t i=0; i<N; i++) {
-      REQUIRE(queue.steal() == gold[i]);
-    }
-    REQUIRE(queue.empty() == true);
+        // concurrent: owner only bulk-pushes, all consumption done by thieves
+        std::vector<std::thread> threads;
+        std::vector<std::vector<void*>> stolens(M);
 
-    // concurrent
-    std::vector<std::thread> threads;
-    std::vector<std::vector<void*>> stolens(M);
+        for(size_t i=0; i<M; ++i) {
+            threads.emplace_back([&, i](){
+                while(consumed != N) {
+                    auto ptr = queue.steal();
+                    if(ptr != nullptr) {
+                        stolens[i].push_back(ptr);
+                        consumed.fetch_add(1, std::memory_order_relaxed);
+                    }
+                }
+                REQUIRE(queue.steal() == nullptr);
+            });
+        }
 
-    for(size_t i=0; i<M; ++i) {
-      threads.emplace_back([&, i](){
+        first = gold.data();
+        queue.bulk_push(first, N);
+
+        // owner waits for thieves to drain (steal-only: owner cannot pop)
         while(consumed != N) {
-          auto ptr = queue.steal();
-          if(ptr != nullptr) {
-            stolens[i].push_back(ptr);
-            consumed.fetch_add(1, std::memory_order_relaxed);
-          }
+            std::this_thread::yield();
         }
         REQUIRE(queue.steal() == nullptr);
-      });
+        REQUIRE(queue.empty());
+
+        for(auto& thread : threads) thread.join();
+
+        std::vector<void*> items;
+        for(size_t i=0; i<M; ++i) {
+            for(auto s : stolens[i]) items.push_back(s);
+        }
+
+        std::sort(items.begin(), items.end());
+        std::sort(gold.begin(),  gold.end());
+        REQUIRE(items.size() == N);
+        REQUIRE(items == gold);
     }
-
-    first = gold.data();
-    queue.bulk_push(first, N);
-
-    std::vector<void*> items;
-    while(consumed != N) {
-      auto ptr = queue.pop();
-      if(ptr != nullptr) {
-        items.push_back(ptr);
-        consumed.fetch_add(1, std::memory_order_relaxed);
-      }
-    }
-    REQUIRE(queue.steal() == nullptr);
-    REQUIRE(queue.pop()   == nullptr);
-    REQUIRE(queue.empty());
-
-    for(auto& thread : threads) thread.join();
-
-    for(size_t i=0; i<M; ++i) {
-      for(auto s : stolens[i]) items.push_back(s);
-    }
-
-    std::sort(items.begin(), items.end());
-    std::sort(gold.begin(),  gold.end());
-    REQUIRE(items.size() == N);
-    REQUIRE(items == gold);
-  }
 }
 
 TEST_CASE("UnboundedWSQ.1Consumer.BulkPush" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers_bulk_push(1);
+    unbounded_wsq_n_consumers_bulk_push(1);
 }
 
 TEST_CASE("UnboundedWSQ.2Consumers.BulkPush" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers_bulk_push(2);
+    unbounded_wsq_n_consumers_bulk_push(2);
 }
 
 TEST_CASE("UnboundedWSQ.3Consumers.BulkPush" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers_bulk_push(3);
+    unbounded_wsq_n_consumers_bulk_push(3);
 }
 
 TEST_CASE("UnboundedWSQ.4Consumers.BulkPush" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers_bulk_push(4);
+    unbounded_wsq_n_consumers_bulk_push(4);
 }
 
 TEST_CASE("UnboundedWSQ.5Consumers.BulkPush" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers_bulk_push(5);
+    unbounded_wsq_n_consumers_bulk_push(5);
 }
 
 TEST_CASE("UnboundedWSQ.6Consumers.BulkPush" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers_bulk_push(6);
+    unbounded_wsq_n_consumers_bulk_push(6);
 }
 
 TEST_CASE("UnboundedWSQ.7Consumers.BulkPush" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers_bulk_push(7);
+    unbounded_wsq_n_consumers_bulk_push(7);
 }
 
 TEST_CASE("UnboundedWSQ.8Consumers.BulkPush" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers_bulk_push(8);
+    unbounded_wsq_n_consumers_bulk_push(8);
 }


### PR DESCRIPTION
           downgrade BoundedWSQ::steal() top load and pop() CAS to relaxed/acq_rel

UnboundedWSQ is used only as the executor's overflow region: the owner only pushes and thieves only steal — the owner never pops. With pop() gone as dead code, the cross-variable Dekker mutual-exclusion structure between top and bottom disappears, and that structure was the sole reason steal() needed a seq_cst fence and a seq_cst CAS. The downgrades follow from this:

UnboundedWSQ::steal()
  - Remove the seq_cst fence: it existed only to pair with pop()'s fence in the single total order S and arbitrate the "last element" race. With no pop(), the fence has nothing to pair with.
  - CAS success order seq_cst -> acq_rel: the only remaining contention is thief-vs-thief on the single variable top. CAS RMW atomicity guarantees exactly one thief wins, and release/acquire is sufficient to chain top's modification order; no cross-variable total order is required.
  - _top.load acquire -> relaxed: top increases monotonically, so relaxed can at worst read a smaller, stale value, making the t<b check conservative (one missed steal, never out of bounds); the CAS then re-validates against the latest top and returns empty on failure. Slot-data visibility is carried by _bottom.load(acquire) paired with push()'s release, independent of how top is read.

BoundedWSQ::steal()
  - Only _top.load acquire -> relaxed. BoundedWSQ still has pop(), so the Dekker structure remains and both the seq_cst fence and the seq_cst CAS are kept unchanged. Relaxing the top load is safe: the seq_cst fence immediately following it is a full barrier that already prevents the top load from being reordered with the subsequent bottom load and slot load — the LoadLoad reordering that acquire was meant to block is already covered by the fence. Slot visibility likewise depends on bottom's acquire chain, not on how top is read.

BoundedWSQ::pop()
  - CAS success order seq_cst -> acq_rel. The seq_cst fence in pop() is retained, and so is steal()'s seq_cst fence and steal()'s seq_cst CAS. The argument that pop()'s CAS need not enter S: * The Dekker / SB exclusion that prevents fast-path double-take is carried entirely by the two seq_cst fences plus steal()'s seq_cst CAS anchor. pop()'s own side is cleanly SB-shaped (store bottom; seq_cst fence; load top), so its fence does the SB duty on its own — pop()'s CAS is not the anchor for either fence. * pop()'s CAS executes only on the t==b (last-element) path, i.e. never on the fast path. That path is single-variable contention: owner-CAS vs thief-CAS both move top from t to t+1, and RMW atomicity guarantees exactly one winner regardless of memory order. acq_rel provides the acquire needed to observe the loser/winner state and the release to publish the claim; entry into the global total order S is not required. Net effect: pop() keeps its seq_cst fence (load-bearing) but drops one seq_cst RMW on the cold last-element path.

Tests (wsq_test.cpp)
  - UnboundedWSQ tests converted to steal-only; all UnboundedWSQ::pop() calls removed. BoundedWSQ tests are untouched (BoundedWSQ still has pop()).
  - UnboundedWSQ.Resize: drain loop pop() -> steal().
  - UnboundedWSQ.Owner / ValueType: dropped the LIFO pop() verification; the pre-existing steal() FIFO check now covers the single-thread path. Removed the now-duplicated second push round.
  - UnboundedWSQ.*Consumers / *.BulkPush: dropped the "master/bulk push and pop" LIFO blocks; in the concurrent phase the owner only pushes and waits (while(consumed != N) yield()) for thieves to drain, since a steal-only owner cannot pop. `items` is now collected solely from `stolens`, and the trailing pop()==nullptr assertion is removed (steal()==nullptr kept).