### PR TITLE
perf(wsq): remove UnboundedWSQ::pop() and relax steal() ordering;

### DIFF
--- a/taskflow/core/executor.hpp
+++ b/taskflow/core/executor.hpp
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "../observer/tfprof.hpp"
 #include "taskflow.hpp"
@@ -1103,7 +1103,7 @@ requires (!std::same_as<std::decay_t<I>, AsyncTask>)
   
   struct Buffer {
     std::mutex mutex;
-    UnboundedWSQ<Node*> queue;
+    OverflowWSQ<Node*> queue;
   };  
   
   std::vector<Worker> _workers;

--- a/taskflow/core/wsq.hpp
+++ b/taskflow/core/wsq.hpp
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <bit>
 
@@ -294,28 +294,6 @@ class UnboundedWSQ {
   void bulk_push(I& first, size_t N);
 
   /**
-  @brief pops out an item from the queue
-
-  This method pops an item from the queue.
-  If the queue is empty, empty_value() is returned.
-  The elements popped out from the queue follow a last-in-first-out (LIFO) order.
-  
-  @code{.cpp}
-  tf::UnboundedWSQ<int> wsq(10);  
-  wsq.push(1);
-  wsq.push(2);
-  wsq.push(3);
-  assert(wsq.pop().value() = 3);
-  assert(wsq.pop().value() = 2);
-  assert(wsq.pop().value() = 1);
-  assert(wsq.pop() == std::nullopt);
-  @endcode
-  
-  Only the owner thread can pop out an item from the queue.
-  */
-  value_type pop();
-
-  /**
   @brief steals an item from the queue
 
   Any threads can try to steal an item from the queue.
@@ -440,46 +418,12 @@ void UnboundedWSQ<T>::bulk_push(I& first, size_t N) {
   _bottom.store(b, std::memory_order_release);
 }
 
-// Function: pop
-template <typename T>
-typename UnboundedWSQ<T>::value_type 
-UnboundedWSQ<T>::pop() {
-
-  int64_t b = _bottom.load(std::memory_order_relaxed) - 1;
-  Array* a = _array.load(std::memory_order_relaxed);
-  _bottom.store(b, std::memory_order_relaxed);
-  std::atomic_thread_fence(std::memory_order_seq_cst);
-  int64_t t = _top.load(std::memory_order_relaxed);
-
-  //T item {nullptr};
-  auto item = empty_value();
-
-  if(t <= b) {
-    item = a->pop(b);
-    if(t == b) {
-      // the last item just got stolen
-      if(!_top.compare_exchange_strong(t, t+1, std::memory_order_seq_cst,
-                                               std::memory_order_relaxed)) {
-        //item = nullptr;
-        item = empty_value();
-      }
-      _bottom.store(b + 1, std::memory_order_relaxed);
-    }
-  }
-  else {
-    _bottom.store(b + 1, std::memory_order_relaxed);
-  }
-
-  return item;
-}
-
 // Function: steal
 template <typename T>
 typename UnboundedWSQ<T>::value_type 
 UnboundedWSQ<T>::steal() {
   
-  int64_t t = _top.load(std::memory_order_acquire);
-  std::atomic_thread_fence(std::memory_order_seq_cst);
+  int64_t t = _top.load(std::memory_order_relaxed);
   int64_t b = _bottom.load(std::memory_order_acquire);
 
   //T item {nullptr};
@@ -489,7 +433,7 @@ UnboundedWSQ<T>::steal() {
     Array* a = _array.load(std::memory_order_consume);
     item = a->pop(t);
     if(!_top.compare_exchange_strong(t, t+1,
-                                     std::memory_order_seq_cst,
+                                     std::memory_order_acq_rel,
                                      std::memory_order_relaxed)) {
       //return nullptr;
       return empty_value();
@@ -833,8 +777,8 @@ BoundedWSQ<T, LogSize>::pop() {
     item = _buffer[b & BufferMask].load(std::memory_order_relaxed);
     if(t == b) {
       // the last item just got stolen
-      if(!_top.compare_exchange_strong(t, t+1, 
-                                       std::memory_order_seq_cst, 
+      if(!_top.compare_exchange_strong(t, t+1,
+                                       std::memory_order_acq_rel,
                                        std::memory_order_relaxed)) {
         //item = nullptr;
         item = empty_value();
@@ -853,7 +797,7 @@ BoundedWSQ<T, LogSize>::pop() {
 template <typename T, size_t LogSize>
 typename BoundedWSQ<T, LogSize>::value_type 
 BoundedWSQ<T, LogSize>::steal() {
-  int64_t t = _top.load(std::memory_order_acquire);
+  int64_t t = _top.load(std::memory_order_relaxed);
   std::atomic_thread_fence(std::memory_order_seq_cst);
   int64_t b = _bottom.load(std::memory_order_acquire);
   

--- a/taskflow/core/wsq.hpp
+++ b/taskflow/core/wsq.hpp
@@ -38,7 +38,7 @@ namespace tf {
 // Work-stealing queue steal protocol sentinels
 //
 // These free functions define the sentinel value used by steal operations
-// across all work-stealing queue types (BoundedWSQ, UnboundedWSQ). They encode
+// across all work-stealing queue types (BoundedWSQ, OverflowWSQ). They encode
 // the result of a steal attempt into the return value itself, avoiding any
 // out-parameter or separate status type.
 //
@@ -104,72 +104,72 @@ tasks without a fixed capacity limit.
 template <typename T>
 class UnboundedWSQ {
 
-  struct Array {
+    struct Array {
 
-    size_t C;
-    size_t M;
-    std::atomic<T>* S;
+        size_t C;
+        size_t M;
+        std::atomic<T>* S;
 
-    explicit Array(size_t c) :
-      C {c},
-      M {c-1},
-      S {new std::atomic<T>[C]} {
-    }
+        explicit Array(size_t c) :
+            C {c},
+            M {c-1},
+            S {new std::atomic<T>[C]} {
+        }
 
-    ~Array() {
-      delete [] S;
-    }
+        ~Array() {
+            delete [] S;
+        }
 
-    size_t capacity() const noexcept {
-      return C;
-    }
+        size_t capacity() const noexcept {
+            return C;
+        }
 
-    void push(int64_t i, T o) noexcept {
-      S[i & M].store(o, std::memory_order_relaxed);
-    }
+        void push(int64_t i, T o) noexcept {
+            S[i & M].store(o, std::memory_order_relaxed);
+        }
 
-    T pop(int64_t i) noexcept {
-      return S[i & M].load(std::memory_order_relaxed);
-    }
+        T pop(int64_t i) noexcept {
+            return S[i & M].load(std::memory_order_relaxed);
+        }
 
-    Array* resize(int64_t b, int64_t t) {
-      Array* ptr = new Array(2*C);
-      for(int64_t i=t; i!=b; ++i) {
-        ptr->push(i, pop(i));
-      }
-      return ptr;
-    }
+        Array* resize(int64_t b, int64_t t) {
+            Array* ptr = new Array(2*C);
+            for(int64_t i=t; i!=b; ++i) {
+                ptr->push(i, pop(i));
+            }
+            return ptr;
+        }
 
-    Array* resize(int64_t b, int64_t t, size_t N) {
-      // assert(N>0);
-      Array* ptr = new Array(std::bit_ceil(C + N));
-      for(int64_t i=t; i!=b; ++i) {
-        ptr->push(i, pop(i));
-      }
-      return ptr;
-    }
+        Array* resize(int64_t b, int64_t t, size_t N) {
+            // assert(N>0);
+            Array* ptr = new Array(std::bit_ceil(C + N));
+            for(int64_t i=t; i!=b; ++i) {
+                ptr->push(i, pop(i));
+            }
+            return ptr;
+        }
 
-  };
+    };
 
-  alignas(TF_CACHELINE_SIZE) std::atomic<int64_t> _top;
-  alignas(TF_CACHELINE_SIZE) std::atomic<int64_t> _bottom;
-  
-  // Owner-private cached upper bound on _top.  Never read by thieves.
-  // Because _top is never decremented, the real occupancy can only be
-  // smaller than what is computed using this cached value, so using it
-  // for the overflow check is always safe.
-  int64_t _cached_top {0};
+    alignas(TF_CACHELINE_SIZE) std::atomic<int64_t> _top;
+    alignas(TF_CACHELINE_SIZE) std::atomic<int64_t> _bottom;
 
-  // _array on its own cache line: avoids false-sharing with _bottom when
-  // thieves load _array (consume) after reading _bottom (acquire).
-  alignas(TF_CACHELINE_SIZE) std::atomic<Array*> _array;
-  std::vector<Array*> _garbage;
+    // Owner-private cached upper bound on _top.  Never read by thieves.
+    // Because _top is never decremented, the real occupancy can only be
+    // smaller than what is computed using this cached value, so using it
+    // for the overflow check is always safe.
+    int64_t _cached_top {0};
 
-  public:
-  
-  /**
+    // _array on its own cache line: avoids false-sharing with _bottom when
+    // thieves load _array (consume) after reading _bottom (acquire).
+    alignas(TF_CACHELINE_SIZE) std::atomic<Array*> _array;
+    std::vector<Array*> _garbage;
+
+public:
+
+    /**
   @brief the return type of queue operations
-  
+
   `value_type` represents the type returned by `pop` and `steal` operations.
   For pointer element types `T`, it is `T` itself and uses `nullptr` to
   indicate an empty result. For non-pointer types, it is `std::optional<T>`,
@@ -179,58 +179,58 @@ class UnboundedWSQ {
   static_assert(std::is_same_v<tf::UnboundedWSQ<int>::value_type, std::optional<int>>);
   static_assert(std::is_same_v<tf::UnboundedWSQ<int*>::value_type, nullptr);
   @endcode
-  
+
   This design avoids the overhead of `std::optional` for pointer types
   while providing a uniform empty-result semantics.
   */
-  using value_type = std::conditional_t<std::is_pointer_v<T>, T, std::optional<T>>;
+    using value_type = std::conditional_t<std::is_pointer_v<T>, T, std::optional<T>>;
 
-  /**
+    /**
   @brief constructs the queue with the given size in the base-2 logarithm
 
   @param LogSize the base-2 logarithm of the queue size
 
   @code{.cpp}
-  tf::UnboundedWSQ<int> wsq(10);  
+  tf::UnboundedWSQ<int> wsq(10);
   assert(wsq.capacity() == 1024);
   @endcode
   */
-  explicit UnboundedWSQ(int64_t LogSize = TF_DEFAULT_UNBOUNDED_TASK_QUEUE_LOG_SIZE);
+    explicit UnboundedWSQ(int64_t LogSize = TF_DEFAULT_UNBOUNDED_TASK_QUEUE_LOG_SIZE);
 
-  /**
+    /**
   @brief destructs the queue
   */
-  ~UnboundedWSQ();
+    ~UnboundedWSQ();
 
-  /**
+    /**
   @brief queries if the queue is empty at the time of this call
-  
+
   @code{.cpp}
-  tf::UnboundedWSQ<int> wsq(10);  
+  tf::UnboundedWSQ<int> wsq(10);
   assert(wsq.empty() == true);
   wsq.push(1);
   assert(wsq.empty() == false);
   @endcode
   */
-  bool empty() const noexcept;
+    bool empty() const noexcept;
 
-  /**
+    /**
   @brief queries the number of items at the time of this call
-  
+
   @code{.cpp}
-  tf::UnboundedWSQ<int> wsq(10);  
+  tf::UnboundedWSQ<int> wsq(10);
   assert(wsq.size() == 0);
   wsq.push(1);
   assert(wsq.size() == 1);
   @endcode
   */
-  size_t size() const noexcept;
+    size_t size() const noexcept;
 
-  /**
+    /**
   @brief queries the capacity of the queue
-  
+
   @code{.cpp}
-  tf::UnboundedWSQ<int> wsq(10);  
+  tf::UnboundedWSQ<int> wsq(10);
   assert(wsq.capacity() == 1024);
   for(int i=0; i<1025; i++){  // insert more than 1024 ints to trigger resizing
     wsq.push(i);
@@ -239,18 +239,18 @@ class UnboundedWSQ {
   assert(wsq.size() == 1025);
   @endcode
   */
-  size_t capacity() const noexcept;
-  
-  /**
+    size_t capacity() const noexcept;
+
+    /**
   @brief inserts an item to the queue
 
   @param item the item to push to the queue
-  
+
   This method pushes one item into the queue.
   The operation can trigger the queue to resize its capacity if more space is required.
-  
+
   @code{.cpp}
-  tf::UnboundedWSQ<int> wsq(10);  
+  tf::UnboundedWSQ<int> wsq(10);
   assert(wsq.capacity() == 1024);
   for(int i=0; i<1025; i++) {   // insert more than 1024 items to trigger resizing
     wsq.push(i);
@@ -258,42 +258,64 @@ class UnboundedWSQ {
   assert(wsq.capacity() == 2048);
   assert(wsq.size() == 1025);
   @endcode
-  
+
   Only the owner thread can insert an item to the queue.
   */
-  void push(T item);
-  
-  /**
+    void push(T item);
+
+    /**
   @brief tries to insert a batch of items into the queue
 
   @tparam I input iterator type
   @param first iterator to the first item in the batch
   @param N number of items to insert beginning at @p first
 
-  This method pushes up to @p N items from the range `[first, first + N)` into the queue. 
-  The operation can trigger the queue to resize its capacity 
+  This method pushes up to @p N items from the range `[first, first + N)` into the queue.
+  The operation can trigger the queue to resize its capacity
   if more space is required.
   The iterator `first` is updated in place and will point to the next uninserted element after the call.
 
   Bulk insertion is often faster than inserting elements one by one because it requires fewer atomic operations.
 
   @code{.cpp}
-  tf::UnboundedWSQ<int> wsq(10);  
+  tf::UnboundedWSQ<int> wsq(10);
   assert(wsq.capacity() == 1024);
   std::vector<int> vec(1025, 1);
   auto first = vec.data();
-  wsq.bulk_push(first, vec.size()); 
+  wsq.bulk_push(first, vec.size());
   assert(wsq.capacity() == 2048);
   assert(wsq.size() == vec.size());
   assert(std::distance(vec.begin(), first) == 1025);
   @endcode
-  
+
   Only the owner thread can insert an item to the queue.
   */
-  template <typename I>
-  void bulk_push(I& first, size_t N);
+    template <typename I>
+    void bulk_push(I& first, size_t N);
 
-  /**
+    /**
+  @brief pops out an item from the queue
+
+  This method pops an item from the queue.
+  If the queue is empty, empty_value() is returned.
+  The elements popped out from the queue follow a last-in-first-out (LIFO) order.
+
+  @code{.cpp}
+  tf::UnboundedWSQ<int> wsq(10);
+  wsq.push(1);
+  wsq.push(2);
+  wsq.push(3);
+  assert(wsq.pop().value() = 3);
+  assert(wsq.pop().value() = 2);
+  assert(wsq.pop().value() = 1);
+  assert(wsq.pop() == std::nullopt);
+  @endcode
+
+  Only the owner thread can pop out an item from the queue.
+  */
+    value_type pop();
+
+    /**
   @brief steals an item from the queue
 
   Any threads can try to steal an item from the queue.
@@ -313,82 +335,82 @@ class UnboundedWSQ {
 
   Multiple threads can simultaneously steal items from the queue.
   */
-  value_type steal();
-  
-  /**
+    value_type steal();
+
+    /**
   @brief returns the empty sentinel value for the queue element type
-  
+
   This function provides a type-appropriate empty value used to indicate
   that a pop or steal operation failed. For pointer types, the empty value
   is `nullptr` of type `T`; for non-pointer types, it is `std::nullopt` of type `std::optional<T>`.
-  
+
   The function is implemented as a `constexpr` helper to avoid additional
   storage, runtime overhead, or code duplication across queue operations.
-  
+
   @return an empty `value_type` representing the absence of an element.
   */
-  static constexpr auto empty_value()     { return wsq_empty_value<T>();     }
+    static constexpr auto empty_value()     { return wsq_empty_value<T>();     }
 
-  private:
+private:
 
-  Array* _resize_array(Array* a, int64_t b, int64_t t);
-  Array* _resize_array(Array* a, int64_t b, int64_t t, size_t N);
+    Array* _resize_array(Array* a, int64_t b, int64_t t);
+    Array* _resize_array(Array* a, int64_t b, int64_t t, size_t N);
 };
 
 // Constructor
 template <typename T>
 UnboundedWSQ<T>::UnboundedWSQ(int64_t LogSize) {
-  _top.store(0, std::memory_order_relaxed);
-  _bottom.store(0, std::memory_order_relaxed);
-  _array.store(new Array{(size_t{1} << LogSize)}, std::memory_order_relaxed);
-  _garbage.reserve(32);
+    _top.store(0, std::memory_order_relaxed);
+    _bottom.store(0, std::memory_order_relaxed);
+    _array.store(new Array{(size_t{1} << LogSize)}, std::memory_order_relaxed);
+    _garbage.reserve(32);
 }
 
 // Destructor
 template <typename T>
 UnboundedWSQ<T>::~UnboundedWSQ() {
-  for(auto a : _garbage) {
-    delete a;
-  }
-  delete _array.load();
+    for(auto a : _garbage) {
+        delete a;
+    }
+    delete _array.load();
 }
 
 // Function: empty
 template <typename T>
 bool UnboundedWSQ<T>::empty() const noexcept {
-  int64_t t = _top.load(std::memory_order_relaxed);
-  int64_t b = _bottom.load(std::memory_order_relaxed);
-  return (b <= t);
+    int64_t t = _top.load(std::memory_order_relaxed);
+    int64_t b = _bottom.load(std::memory_order_relaxed);
+    return (b <= t);
 }
 
 // Function: size
 template <typename T>
 size_t UnboundedWSQ<T>::size() const noexcept {
-  int64_t t = _top.load(std::memory_order_relaxed);
-  int64_t b = _bottom.load(std::memory_order_relaxed);
-  return static_cast<size_t>(b >= t ? b - t : 0);
+    int64_t t = _top.load(std::memory_order_relaxed);
+    int64_t b = _bottom.load(std::memory_order_relaxed);
+    return static_cast<size_t>(b >= t ? b - t : 0);
 }
 
 // Function: push
 template <typename T>
 void UnboundedWSQ<T>::push(T o) {
 
-  int64_t b = _bottom.load(std::memory_order_relaxed);
-  Array* a = _array.load(std::memory_order_relaxed);
+    int64_t b = _bottom.load(std::memory_order_relaxed);
+    Array* a = _array.load(std::memory_order_relaxed);
 
-  // queue is full with one additional item (b-t+1)
-  if(a->capacity() < static_cast<size_t>(b - _cached_top + 1)) [[unlikely]] {
-    _cached_top = _top.load(std::memory_order_acquire);
+    // queue is full with one additional item (b-t+1)
     if(a->capacity() < static_cast<size_t>(b - _cached_top + 1)) [[unlikely]] {
-      a = _resize_array(a, b, _cached_top);
+        _cached_top = _top.load(std::memory_order_acquire);
+        if(a->capacity() < static_cast<size_t>(b - _cached_top + 1)) [[unlikely]] {
+            a = _resize_array(a, b, _cached_top);
+        }
     }
-  }
 
-  a->push(b, o);
-  std::atomic_thread_fence(std::memory_order_release);
+    a->push(b, o);
+    std::atomic_thread_fence(std::memory_order_release);
 
-  // original paper uses relaxed here but tsa complains
-  _bottom.store(b + 1, std::memory_order_release);
+    // original paper uses relaxed here but tsa complains
+    _bottom.store(b + 1, std::memory_order_release);
 }
 
 // Function: bulk_push
@@ -396,79 +418,114 @@ template <typename T>
 template <typename I>
 void UnboundedWSQ<T>::bulk_push(I& first, size_t N) {
 
-  if(N == 0) return;
+    if(N == 0) return;
 
-  int64_t b = _bottom.load(std::memory_order_relaxed);
-  Array* a = _array.load(std::memory_order_relaxed);
+    int64_t b = _bottom.load(std::memory_order_relaxed);
+    Array* a = _array.load(std::memory_order_relaxed);
 
-  // queue is full with N additional items
-  if((b - _cached_top + N) > a->capacity()) [[unlikely]] {
-    _cached_top = _top.load(std::memory_order_acquire);
+    // queue is full with N additional items
     if((b - _cached_top + N) > a->capacity()) [[unlikely]] {
-      a = _resize_array(a, b, _cached_top, N);
+        _cached_top = _top.load(std::memory_order_acquire);
+        if((b - _cached_top + N) > a->capacity()) [[unlikely]] {
+            a = _resize_array(a, b, _cached_top, N);
+        }
     }
-  }
 
-  for(size_t i=0; i<N; ++i) {
-    a->push(b++, *first++);
-  }
-  std::atomic_thread_fence(std::memory_order_release);
+    for(size_t i=0; i<N; ++i) {
+        a->push(b++, *first++);
+    }
+    std::atomic_thread_fence(std::memory_order_release);
 
-  // original paper uses relaxed here but tsa complains
-  _bottom.store(b, std::memory_order_release);
+    // original paper uses relaxed here but tsa complains
+    _bottom.store(b, std::memory_order_release);
+}
+
+// Function: pop
+template <typename T>
+typename UnboundedWSQ<T>::value_type
+UnboundedWSQ<T>::pop() {
+
+    int64_t b = _bottom.load(std::memory_order_relaxed) - 1;
+    Array* a = _array.load(std::memory_order_relaxed);
+    _bottom.store(b, std::memory_order_relaxed);
+    std::atomic_thread_fence(std::memory_order_seq_cst);
+    int64_t t = _top.load(std::memory_order_relaxed);
+
+    //T item {nullptr};
+    auto item = empty_value();
+
+    if(t <= b) {
+        item = a->pop(b);
+        if(t == b) {
+            // the last item just got stolen
+            if(!_top.compare_exchange_strong(t, t+1, std::memory_order_acq_rel,
+                                              std::memory_order_relaxed)) {
+                //item = nullptr;
+                item = empty_value();
+            }
+            _bottom.store(b + 1, std::memory_order_relaxed);
+        }
+    }
+    else {
+        _bottom.store(b + 1, std::memory_order_relaxed);
+    }
+
+    return item;
 }
 
 // Function: steal
 template <typename T>
-typename UnboundedWSQ<T>::value_type 
+typename UnboundedWSQ<T>::value_type
 UnboundedWSQ<T>::steal() {
-  
-  int64_t t = _top.load(std::memory_order_relaxed);
-  int64_t b = _bottom.load(std::memory_order_acquire);
 
-  //T item {nullptr};
-  auto item = empty_value();
+    int64_t t = _top.load(std::memory_order_relaxed);
+    std::atomic_thread_fence(std::memory_order_seq_cst);
+    int64_t b = _bottom.load(std::memory_order_acquire);
 
-  if(t < b) {
-    Array* a = _array.load(std::memory_order_consume);
-    item = a->pop(t);
-    if(!_top.compare_exchange_strong(t, t+1,
-                                     std::memory_order_acq_rel,
-                                     std::memory_order_relaxed)) {
-      //return nullptr;
-      return empty_value();
+    //T item {nullptr};
+    auto item = empty_value();
+
+    if(t < b) {
+        Array* a = _array.load(std::memory_order_consume);
+        item = a->pop(t);
+        if(!_top.compare_exchange_strong(t, t+1,
+                                          std::memory_order_seq_cst,
+                                          std::memory_order_relaxed)) {
+            //return nullptr;
+            return empty_value();
+        }
     }
-  }
 
-  return item;
+    return item;
 }
 
 
 // Function: capacity
 template <typename T>
 size_t UnboundedWSQ<T>::capacity() const noexcept {
-  return _array.load(std::memory_order_relaxed)->capacity();
+    return _array.load(std::memory_order_relaxed)->capacity();
 }
 
 template <typename T>
 typename UnboundedWSQ<T>::Array*
 UnboundedWSQ<T>::_resize_array(Array* a, int64_t b, int64_t t) {
-  Array* tmp = a->resize(b, t);
-  _garbage.push_back(a);
-  // Note: the original paper using relaxed causes t-san to complain
-  _array.store(tmp, std::memory_order_release);
-  return tmp;
+    Array* tmp = a->resize(b, t);
+    _garbage.push_back(a);
+    // Note: the original paper using relaxed causes t-san to complain
+    _array.store(tmp, std::memory_order_release);
+    return tmp;
 }
 
 template <typename T>
 typename UnboundedWSQ<T>::Array*
 UnboundedWSQ<T>::_resize_array(Array* a, int64_t b, int64_t t, size_t N) {
-  Array* tmp = a->resize(b, t, N);
-  _garbage.push_back(a);
-  // Note: the original paper using relaxed causes t-san to complain
-  _array.store(tmp, std::memory_order_release);
-  return tmp;
+    Array* tmp = a->resize(b, t, N);
+    _garbage.push_back(a);
+    // Note: the original paper using relaxed causes t-san to complain
+    _array.store(tmp, std::memory_order_release);
+    return tmp;
 }
+
 
 // ----------------------------------------------------------------------------
 // Bounded Work-stealing Queue (WSQ)
@@ -522,8 +579,8 @@ class BoundedWSQ {
   where `std::nullopt` denotes the absence of a value.
   
   @code{.cpp}
-  static_assert(std::is_same_v<tf::UnboundedWSQ<int>::value_type, std::optional<int>>);
-  static_assert(std::is_same_v<tf::UnboundedWSQ<int*>::value_type, nullptr);
+  static_assert(std::is_same_v<tf::OverflowWSQ<int>::value_type, std::optional<int>>);
+  static_assert(std::is_same_v<tf::OverflowWSQ<int*>::value_type, nullptr);
   @endcode
   
   This design avoids the overhead of `std::optional` for pointer types
@@ -824,5 +881,402 @@ constexpr size_t BoundedWSQ<T, LogSize>::capacity() const {
   return BufferSize;
 }
 
+// ----------------------------------------------------------------------------
+// Overflow Work-stealing Queue (WSQ)
+// ----------------------------------------------------------------------------
+
+
+/**
+@class: OverflowWSQ
+
+@tparam T data type (must be a pointer type)
+
+@brief class to create a lock-free unbounded work-stealing queue
+
+This class implements the work-stealing queue described in the paper,
+<a href="https://www.di.ens.fr/~zappa/readings/ppopp13.pdf">
+Correct and Efficient Work-Stealing for Weak Memory Models</a>.
+
+A work-stealing queue supports a single owner thread that performs push and pop
+operations, while multiple concurrent thief threads may steal tasks
+from the opposite end of the queue. The implementation is designed to
+operate correctly under weak memory models and uses atomic operations
+with carefully chosen memory orderings to ensure correctness and
+scalability.
+
+@dotfile images/unbounded_wsq.dot
+
+Unlike bounded queues, this queue automatically grows its internal
+storage as needed, allowing it to accommodate an arbitrary number of
+tasks without a fixed capacity limit.
+*/
+template <typename T>
+class OverflowWSQ {
+
+    struct Array {
+
+        size_t C;
+        size_t M;
+        std::atomic<T>* S;
+
+        explicit Array(size_t c) :
+            C {c},
+            M {c-1},
+            S {new std::atomic<T>[C]} {
+        }
+
+        ~Array() {
+            delete [] S;
+        }
+
+        size_t capacity() const noexcept {
+            return C;
+        }
+
+        void push(int64_t i, T o) noexcept {
+            S[i & M].store(o, std::memory_order_relaxed);
+        }
+
+        T pop(int64_t i) noexcept {
+            return S[i & M].load(std::memory_order_relaxed);
+        }
+
+        Array* resize(int64_t b, int64_t t) {
+            Array* ptr = new Array(2*C);
+            for(int64_t i=t; i!=b; ++i) {
+                ptr->push(i, pop(i));
+            }
+            return ptr;
+        }
+
+        Array* resize(int64_t b, int64_t t, size_t N) {
+            // assert(N>0);
+            Array* ptr = new Array(std::bit_ceil(C + N));
+            for(int64_t i=t; i!=b; ++i) {
+                ptr->push(i, pop(i));
+            }
+            return ptr;
+        }
+
+    };
+
+    alignas(TF_CACHELINE_SIZE) std::atomic<int64_t> _top;
+    alignas(TF_CACHELINE_SIZE) std::atomic<int64_t> _bottom;
+
+    // Owner-private cached upper bound on _top.  Never read by thieves.
+    // Because _top is never decremented, the real occupancy can only be
+    // smaller than what is computed using this cached value, so using it
+    // for the overflow check is always safe.
+    int64_t _cached_top {0};
+
+    // _array on its own cache line: avoids false-sharing with _bottom when
+    // thieves load _array (consume) after reading _bottom (acquire).
+    alignas(TF_CACHELINE_SIZE) std::atomic<Array*> _array;
+    std::vector<Array*> _garbage;
+
+public:
+
+    /**
+  @brief the return type of queue operations
+
+  `value_type` represents the type returned by `pop` and `steal` operations.
+  For pointer element types `T`, it is `T` itself and uses `nullptr` to
+  indicate an empty result. For non-pointer types, it is `std::optional<T>`,
+  where `std::nullopt` denotes the absence of a value.
+
+  @code{.cpp}
+  static_assert(std::is_same_v<tf::OverflowWSQ<int>::value_type, std::optional<int>>);
+  static_assert(std::is_same_v<tf::OverflowWSQ<int*>::value_type, nullptr);
+  @endcode
+
+  This design avoids the overhead of `std::optional` for pointer types
+  while providing a uniform empty-result semantics.
+  */
+    using value_type = std::conditional_t<std::is_pointer_v<T>, T, std::optional<T>>;
+
+    /**
+  @brief constructs the queue with the given size in the base-2 logarithm
+
+  @param LogSize the base-2 logarithm of the queue size
+
+  @code{.cpp}
+  tf::OverflowWSQ<int> wsq(10);
+  assert(wsq.capacity() == 1024);
+  @endcode
+  */
+    explicit OverflowWSQ(int64_t LogSize = TF_DEFAULT_UNBOUNDED_TASK_QUEUE_LOG_SIZE);
+
+    /**
+  @brief destructs the queue
+  */
+    ~OverflowWSQ();
+
+    /**
+  @brief queries if the queue is empty at the time of this call
+
+  @code{.cpp}
+  tf::OverflowWSQ<int> wsq(10);
+  assert(wsq.empty() == true);
+  wsq.push(1);
+  assert(wsq.empty() == false);
+  @endcode
+  */
+    bool empty() const noexcept;
+
+    /**
+  @brief queries the number of items at the time of this call
+
+  @code{.cpp}
+  tf::OverflowWSQ<int> wsq(10);
+  assert(wsq.size() == 0);
+  wsq.push(1);
+  assert(wsq.size() == 1);
+  @endcode
+  */
+    size_t size() const noexcept;
+
+    /**
+  @brief queries the capacity of the queue
+
+  @code{.cpp}
+  tf::OverflowWSQ<int> wsq(10);
+  assert(wsq.capacity() == 1024);
+  for(int i=0; i<1025; i++){  // insert more than 1024 ints to trigger resizing
+    wsq.push(i);
+  }
+  assert(wsq.capacity() == 2048);
+  assert(wsq.size() == 1025);
+  @endcode
+  */
+    size_t capacity() const noexcept;
+
+    /**
+  @brief inserts an item to the queue
+
+  @param item the item to push to the queue
+
+  This method pushes one item into the queue.
+  The operation can trigger the queue to resize its capacity if more space is required.
+
+  @code{.cpp}
+  tf::OverflowWSQ<int> wsq(10);
+  assert(wsq.capacity() == 1024);
+  for(int i=0; i<1025; i++) {   // insert more than 1024 items to trigger resizing
+    wsq.push(i);
+  }
+  assert(wsq.capacity() == 2048);
+  assert(wsq.size() == 1025);
+  @endcode
+
+  Only the owner thread can insert an item to the queue.
+  */
+    void push(T item);
+
+    /**
+  @brief tries to insert a batch of items into the queue
+
+  @tparam I input iterator type
+  @param first iterator to the first item in the batch
+  @param N number of items to insert beginning at @p first
+
+  This method pushes up to @p N items from the range `[first, first + N)` into the queue.
+  The operation can trigger the queue to resize its capacity
+  if more space is required.
+  The iterator `first` is updated in place and will point to the next uninserted element after the call.
+
+  Bulk insertion is often faster than inserting elements one by one because it requires fewer atomic operations.
+
+  @code{.cpp}
+  tf::OverflowWSQ<int> wsq(10);
+  assert(wsq.capacity() == 1024);
+  std::vector<int> vec(1025, 1);
+  auto first = vec.data();
+  wsq.bulk_push(first, vec.size());
+  assert(wsq.capacity() == 2048);
+  assert(wsq.size() == vec.size());
+  assert(std::distance(vec.begin(), first) == 1025);
+  @endcode
+
+  Only the owner thread can insert an item to the queue.
+  */
+    template <typename I>
+    void bulk_push(I& first, size_t N);
+
+    /**
+  @brief steals an item from the queue
+
+  Any threads can try to steal an item from the queue.
+  The return can be an empty_value() if this operation failed.
+  The elements stolen from the queue follow a first-in-first-out (FIFO) order.
+
+  @code{.cpp}
+  tf::OverflowWSQ<int> wsq(10);
+  wsq.push(1);
+  wsq.push(2);
+  wsq.push(3);
+  assert(wsq.steal().value() = 1);
+  assert(wsq.steal().value() = 2);
+  assert(wsq.steal().value() = 3);
+  assert(wsq.steal() == std::nullopt);
+  @endcode
+
+  Multiple threads can simultaneously steal items from the queue.
+  */
+    value_type steal();
+
+    /**
+  @brief returns the empty sentinel value for the queue element type
+
+  This function provides a type-appropriate empty value used to indicate
+  that a pop or steal operation failed. For pointer types, the empty value
+  is `nullptr` of type `T`; for non-pointer types, it is `std::nullopt` of type `std::optional<T>`.
+
+  The function is implemented as a `constexpr` helper to avoid additional
+  storage, runtime overhead, or code duplication across queue operations.
+
+  @return an empty `value_type` representing the absence of an element.
+  */
+    static constexpr auto empty_value()     { return wsq_empty_value<T>();     }
+
+private:
+
+    Array* _resize_array(Array* a, int64_t b, int64_t t);
+    Array* _resize_array(Array* a, int64_t b, int64_t t, size_t N);
+};
+
+// Constructor
+template <typename T>
+OverflowWSQ<T>::OverflowWSQ(int64_t LogSize) {
+    _top.store(0, std::memory_order_relaxed);
+    _bottom.store(0, std::memory_order_relaxed);
+    _array.store(new Array{(size_t{1} << LogSize)}, std::memory_order_relaxed);
+    _garbage.reserve(32);
+}
+
+// Destructor
+template <typename T>
+OverflowWSQ<T>::~OverflowWSQ() {
+    for(auto a : _garbage) {
+        delete a;
+    }
+    delete _array.load();
+}
+
+// Function: empty
+template <typename T>
+bool OverflowWSQ<T>::empty() const noexcept {
+    int64_t t = _top.load(std::memory_order_relaxed);
+    int64_t b = _bottom.load(std::memory_order_relaxed);
+    return (b <= t);
+}
+
+// Function: size
+template <typename T>
+size_t OverflowWSQ<T>::size() const noexcept {
+    int64_t t = _top.load(std::memory_order_relaxed);
+    int64_t b = _bottom.load(std::memory_order_relaxed);
+    return static_cast<size_t>(b >= t ? b - t : 0);
+}
+
+// Function: push
+template <typename T>
+void OverflowWSQ<T>::push(T o) {
+
+    int64_t b = _bottom.load(std::memory_order_relaxed);
+    Array* a = _array.load(std::memory_order_relaxed);
+
+    // queue is full with one additional item (b-t+1)
+    if(a->capacity() < static_cast<size_t>(b - _cached_top + 1)) [[unlikely]] {
+        _cached_top = _top.load(std::memory_order_acquire);
+        if(a->capacity() < static_cast<size_t>(b - _cached_top + 1)) [[unlikely]] {
+            a = _resize_array(a, b, _cached_top);
+        }
+    }
+
+    a->push(b, o);
+    std::atomic_thread_fence(std::memory_order_release);
+
+    // original paper uses relaxed here but tsa complains
+    _bottom.store(b + 1, std::memory_order_release);
+}
+
+// Function: bulk_push
+template <typename T>
+template <typename I>
+void OverflowWSQ<T>::bulk_push(I& first, size_t N) {
+
+    if(N == 0) return;
+
+    int64_t b = _bottom.load(std::memory_order_relaxed);
+    Array* a = _array.load(std::memory_order_relaxed);
+
+    // queue is full with N additional items
+    if((b - _cached_top + N) > a->capacity()) [[unlikely]] {
+        _cached_top = _top.load(std::memory_order_acquire);
+        if((b - _cached_top + N) > a->capacity()) [[unlikely]] {
+            a = _resize_array(a, b, _cached_top, N);
+        }
+    }
+
+    for(size_t i=0; i<N; ++i) {
+        a->push(b++, *first++);
+    }
+    std::atomic_thread_fence(std::memory_order_release);
+
+    // original paper uses relaxed here but tsa complains
+    _bottom.store(b, std::memory_order_release);
+}
+
+// Function: steal
+template <typename T>
+typename OverflowWSQ<T>::value_type
+OverflowWSQ<T>::steal() {
+
+    int64_t t = _top.load(std::memory_order_relaxed);
+    int64_t b = _bottom.load(std::memory_order_acquire);
+
+    //T item {nullptr};
+    auto item = empty_value();
+
+    if(t < b) {
+        Array* a = _array.load(std::memory_order_consume);
+        item = a->pop(t);
+        if(!_top.compare_exchange_strong(t, t+1,
+                                          std::memory_order_acq_rel,
+                                          std::memory_order_relaxed)) {
+            //return nullptr;
+            return empty_value();
+        }
+    }
+
+    return item;
+}
+
+
+// Function: capacity
+template <typename T>
+size_t OverflowWSQ<T>::capacity() const noexcept {
+    return _array.load(std::memory_order_relaxed)->capacity();
+}
+
+template <typename T>
+typename OverflowWSQ<T>::Array*
+OverflowWSQ<T>::_resize_array(Array* a, int64_t b, int64_t t) {
+    Array* tmp = a->resize(b, t);
+    _garbage.push_back(a);
+    // Note: the original paper using relaxed causes t-san to complain
+    _array.store(tmp, std::memory_order_release);
+    return tmp;
+}
+
+template <typename T>
+typename OverflowWSQ<T>::Array*
+OverflowWSQ<T>::_resize_array(Array* a, int64_t b, int64_t t, size_t N) {
+    Array* tmp = a->resize(b, t, N);
+    _garbage.push_back(a);
+    // Note: the original paper using relaxed causes t-san to complain
+    _array.store(tmp, std::memory_order_release);
+    return tmp;
+}
 
 }  // end of namespace tf -----------------------------------------------------

--- a/unittests/test_wsq.cpp
+++ b/unittests/test_wsq.cpp
@@ -15,80 +15,80 @@
 template<size_t LogSize>
 void bounded_wsq_owner() {
 
-    tf::BoundedWSQ<void*, LogSize> queue;
+  tf::BoundedWSQ<void*, LogSize> queue;
 
-    constexpr size_t N = (1 << LogSize);
+  constexpr size_t N = (1 << LogSize);
 
-    std::vector<void*> data(1);  // dummy space to avoid nullptr when calling .data
+  std::vector<void*> data(1);  // dummy space to avoid nullptr when calling .data
 
-    for(size_t k=0; k<LogSize*10; k++) {
+  for(size_t k=0; k<LogSize*10; k++) {
 
-        data.clear();
+    data.clear();
 
-        REQUIRE(queue.empty() == true);
+    REQUIRE(queue.empty() == true);
 
-        for(size_t i=0; i<N; i++) {
-            auto ptr = data.data() + i;
-            REQUIRE(queue.try_push(ptr) == true);
-            data.push_back(ptr);
-        }
-        REQUIRE(queue.try_push(nullptr) == false);
+    for(size_t i=0; i<N; i++) {
+      auto ptr = data.data() + i;
+      REQUIRE(queue.try_push(ptr) == true);
+      data.push_back(ptr);
+    }
+    REQUIRE(queue.try_push(nullptr) == false);
 
-        for(size_t i=0; i<N; i++) {
-            auto item = queue.pop();
-            REQUIRE(item != nullptr);
-            REQUIRE(item == data[N-i-1]);
-        }
-
-        for(size_t i=0; i<N; i++) {
-            REQUIRE(queue.pop() == nullptr);
-        }
+    for(size_t i=0; i<N; i++) {
+      auto item = queue.pop();
+      REQUIRE(item != nullptr);
+      REQUIRE(item == data[N-i-1]);
     }
 
-    // test steal (plain, two-state)
-    size_t dummy1, dummy2;
+    for(size_t i=0; i<N; i++) {
+      REQUIRE(queue.pop() == nullptr);
+    }
+  }
 
-    REQUIRE(queue.try_push(&dummy1) == true);
-    REQUIRE(queue.try_push(&dummy2) == true);
-    REQUIRE(queue.steal() == &dummy1);
-    REQUIRE(queue.steal() == &dummy2);
-    REQUIRE(queue.steal() == nullptr);
+  // test steal (plain, two-state)
+  size_t dummy1, dummy2;
+
+  REQUIRE(queue.try_push(&dummy1) == true);
+  REQUIRE(queue.try_push(&dummy2) == true);
+  REQUIRE(queue.steal() == &dummy1);
+  REQUIRE(queue.steal() == &dummy2);
+  REQUIRE(queue.steal() == nullptr);
 }
 
 TEST_CASE("BoundedWSQ.Owner.LogSize=2" * doctest::timeout(300)) {
-    bounded_wsq_owner<2>();
+  bounded_wsq_owner<2>();
 }
 
 TEST_CASE("BoundedWSQ.Owner.LogSize=3" * doctest::timeout(300)) {
-    bounded_wsq_owner<3>();
+  bounded_wsq_owner<3>();
 }
 
 TEST_CASE("BoundedWSQ.Owner.LogSize=4" * doctest::timeout(300)) {
-    bounded_wsq_owner<4>();
+  bounded_wsq_owner<4>();
 }
 
 TEST_CASE("BoundedWSQ.Owner.LogSize=5" * doctest::timeout(300)) {
-    bounded_wsq_owner<5>();
+  bounded_wsq_owner<5>();
 }
 
 TEST_CASE("BoundedWSQ.Owner.LogSize=6" * doctest::timeout(300)) {
-    bounded_wsq_owner<6>();
+  bounded_wsq_owner<6>();
 }
 
 TEST_CASE("BoundedWSQ.Owner.LogSize=7" * doctest::timeout(300)) {
-    bounded_wsq_owner<7>();
+  bounded_wsq_owner<7>();
 }
 
 TEST_CASE("BoundedWSQ.Owner.LogSize=8" * doctest::timeout(300)) {
-    bounded_wsq_owner<8>();
+  bounded_wsq_owner<8>();
 }
 
 TEST_CASE("BoundedWSQ.Owner.LogSize=9" * doctest::timeout(300)) {
-    bounded_wsq_owner<9>();
+  bounded_wsq_owner<9>();
 }
 
 TEST_CASE("BoundedWSQ.Owner.LogSize=10" * doctest::timeout(300)) {
-    bounded_wsq_owner<10>();
+  bounded_wsq_owner<10>();
 }
 
 
@@ -98,10 +98,375 @@ TEST_CASE("BoundedWSQ.Owner.LogSize=10" * doctest::timeout(300)) {
 // ----------------------------------------------------------------------------
 
 TEST_CASE("BoundedWSQ.ValueType") {
-    tf::BoundedWSQ<void*> Q1;
-    tf::BoundedWSQ<int>   Q2;
+  tf::BoundedWSQ<void*> Q1;
+  tf::BoundedWSQ<int>   Q2;
 
-    // empty_value(): nullptr for pointer types, nullopt for non-pointer
+  // empty_value(): nullptr for pointer types, nullopt for non-pointer
+  auto empty1 = Q1.empty_value();
+  auto empty2 = Q2.empty_value();
+
+  static_assert(std::is_same_v<decltype(empty1), void*>);
+  static_assert(std::is_same_v<decltype(empty2), std::optional<int>>);
+
+  REQUIRE(empty1 == nullptr);
+  REQUIRE(empty2 == std::nullopt);
+
+  // push/pop/steal still work normally
+  auto v = Q2.pop();
+  REQUIRE(v == std::nullopt);
+
+  Q2.try_push(1);
+  Q2.try_push(2);
+  Q2.try_push(3);
+  Q2.try_push(4);
+
+  REQUIRE(Q2.pop()   == 4);
+  REQUIRE(Q2.pop()   == 3);
+  REQUIRE(Q2.pop()   == 2);
+  REQUIRE(Q2.pop()   == 1);
+  REQUIRE(Q2.pop()   == std::nullopt);
+
+  Q2.try_push(1);
+  Q2.try_push(2);
+  Q2.try_push(3);
+  Q2.try_push(4);
+  REQUIRE(Q2.steal() == 1);
+  REQUIRE(Q2.steal() == 2);
+  REQUIRE(Q2.steal() == 3);
+  REQUIRE(Q2.steal() == 4);
+  REQUIRE(Q2.steal() == std::nullopt);
+}
+
+// ----------------------------------------------------------------------------
+// BoundedWSQ Multiple Consumers Test (original, using plain steal)
+// ----------------------------------------------------------------------------
+
+void bounded_wsq_n_consumers(size_t M) {
+
+  tf::BoundedWSQ<void*> queue;
+
+  std::vector<void*> gold;
+  std::atomic<size_t> consumed;
+
+  // 1, 4, 13, 40, 121, 364, 1093, 3280, 9841, 29524, 88573
+  for(size_t N=1; N<=88573; N=N*3+1) {
+
+    REQUIRE(queue.empty());
+
+    gold.resize(N);
+    consumed = 0;
+
+    for(size_t i=0; i<N; ++i) {
+      gold[i] = gold.data() + i;
+    }
+
+    std::vector<std::thread> threads;
+    std::vector<std::vector<void*>> stolens(M);
+
+    for(size_t i=0; i<M; ++i) {
+      threads.emplace_back([&, i](){
+        while(consumed != N) {
+          auto ptr = queue.steal();
+          if(ptr != nullptr) {
+            stolens[i].push_back(ptr);
+            consumed.fetch_add(1, std::memory_order_relaxed);
+          }
+        }
+        REQUIRE(queue.steal() == nullptr);
+      });
+    }
+
+    for(size_t i=0; i<N; ++i) {
+      while(queue.try_push(gold[i]) == false);
+    }
+
+    std::vector<void*> items;
+    while(consumed != N) {
+      auto ptr = queue.pop();
+      if(ptr != nullptr) {
+        items.push_back(ptr);
+        consumed.fetch_add(1, std::memory_order_relaxed);
+      }
+    }
+    REQUIRE(queue.steal() == nullptr);
+    REQUIRE(queue.pop()   == nullptr);
+    REQUIRE(queue.empty());
+
+    for(auto& thread : threads) thread.join();
+
+    for(size_t i=0; i<M; ++i) {
+      for(auto s : stolens[i]) items.push_back(s);
+    }
+
+    std::sort(items.begin(), items.end());
+    std::sort(gold.begin(),  gold.end());
+    REQUIRE(items.size() == N);
+    REQUIRE(items == gold);
+  }
+}
+
+TEST_CASE("BoundedWSQ.1Consumer" * doctest::timeout(300)) {
+  bounded_wsq_n_consumers(1);
+}
+
+TEST_CASE("BoundedWSQ.2Consumers" * doctest::timeout(300)) {
+  bounded_wsq_n_consumers(2);
+}
+
+TEST_CASE("BoundedWSQ.3Consumers" * doctest::timeout(300)) {
+  bounded_wsq_n_consumers(3);
+}
+
+TEST_CASE("BoundedWSQ.4Consumers" * doctest::timeout(300)) {
+  bounded_wsq_n_consumers(4);
+}
+
+TEST_CASE("BoundedWSQ.5Consumers" * doctest::timeout(300)) {
+  bounded_wsq_n_consumers(5);
+}
+
+TEST_CASE("BoundedWSQ.6Consumers" * doctest::timeout(300)) {
+  bounded_wsq_n_consumers(6);
+}
+
+TEST_CASE("BoundedWSQ.7Consumers" * doctest::timeout(300)) {
+  bounded_wsq_n_consumers(7);
+}
+
+TEST_CASE("BoundedWSQ.8Consumers" * doctest::timeout(300)) {
+  bounded_wsq_n_consumers(8);
+}
+
+// ----------------------------------------------------------------------------
+// BoundedWSQ Multiple Consumers BulkPush Test
+// ----------------------------------------------------------------------------
+
+void bounded_wsq_n_consumers_bulk_push(size_t M) {
+
+  tf::BoundedWSQ<void*> queue;
+
+  std::vector<void*> gold;
+  std::atomic<size_t> consumed;
+
+  // 1, 4, 13, 40, 121, 364, 1093, 3280, 9841, 29524, 88573
+  for(size_t N=1; N<=88573; N=N*3+1) {
+
+    REQUIRE(queue.empty());
+
+    gold.resize(N);
+    consumed = 0;
+
+    for(size_t i=0; i<N; ++i) {
+      gold[i] = gold.data() + i;
+    }
+
+    size_t capacity = queue.capacity();
+    const size_t num_pushable = std::min(capacity, N);
+
+    // bulk push and pop
+    auto first = gold.data();
+    REQUIRE(num_pushable == queue.try_bulk_push(first, N));
+    REQUIRE(queue.size() == num_pushable);
+    for(size_t i=0; i<num_pushable; i++) {
+      REQUIRE(queue.pop() == gold[num_pushable - i - 1]);
+    }
+    REQUIRE(queue.empty() == true);
+
+    // bulk push and steal
+    first = gold.data();
+    REQUIRE(num_pushable == queue.try_bulk_push(first, N));
+    REQUIRE(queue.size() == num_pushable);
+    for(size_t i=0; i<num_pushable; i++) {
+      REQUIRE(queue.steal() == gold[i]);
+    }
+    REQUIRE(queue.empty() == true);
+
+    // concurrent bulk push + thieves
+    std::vector<std::thread> threads;
+    std::vector<std::vector<void*>> stolens(M);
+
+    for(size_t i=0; i<M; ++i) {
+      threads.emplace_back([&, i](){
+        while(consumed != N) {
+          auto ptr = queue.steal();
+          if(ptr != nullptr) {
+            stolens[i].push_back(ptr);
+            consumed.fetch_add(1, std::memory_order_relaxed);
+          }
+        }
+        REQUIRE(queue.steal() == nullptr);
+      });
+    }
+
+    first = gold.data();
+    for(size_t n=0; n<N;) {
+      n += queue.try_bulk_push(first, N-n);
+    }
+
+    std::vector<void*> items;
+    while(consumed != N) {
+      auto ptr = queue.pop();
+      if(ptr != nullptr) {
+        items.push_back(ptr);
+        consumed.fetch_add(1, std::memory_order_relaxed);
+      }
+    }
+    REQUIRE(queue.steal() == nullptr);
+    REQUIRE(queue.pop()   == nullptr);
+    REQUIRE(queue.empty());
+
+    for(auto& thread : threads) thread.join();
+
+    for(size_t i=0; i<M; ++i) {
+      for(auto s : stolens[i]) items.push_back(s);
+    }
+
+    std::sort(items.begin(), items.end());
+    std::sort(gold.begin(),  gold.end());
+    REQUIRE(items.size() == N);
+    REQUIRE(items == gold);
+  }
+}
+
+TEST_CASE("BoundedWSQ.1Consumer.BulkPush" * doctest::timeout(300)) {
+  bounded_wsq_n_consumers_bulk_push(1);
+}
+
+TEST_CASE("BoundedWSQ.2Consumers.BulkPush" * doctest::timeout(300)) {
+  bounded_wsq_n_consumers_bulk_push(2);
+}
+
+TEST_CASE("BoundedWSQ.3Consumers.BulkPush" * doctest::timeout(300)) {
+  bounded_wsq_n_consumers_bulk_push(3);
+}
+
+TEST_CASE("BoundedWSQ.4Consumers.BulkPush" * doctest::timeout(300)) {
+  bounded_wsq_n_consumers_bulk_push(4);
+}
+
+TEST_CASE("BoundedWSQ.5Consumers.BulkPush" * doctest::timeout(300)) {
+  bounded_wsq_n_consumers_bulk_push(5);
+}
+
+TEST_CASE("BoundedWSQ.6Consumers.BulkPush" * doctest::timeout(300)) {
+  bounded_wsq_n_consumers_bulk_push(6);
+}
+
+TEST_CASE("BoundedWSQ.7Consumers.BulkPush" * doctest::timeout(300)) {
+  bounded_wsq_n_consumers_bulk_push(7);
+}
+
+TEST_CASE("BoundedWSQ.8Consumers.BulkPush" * doctest::timeout(300)) {
+  bounded_wsq_n_consumers_bulk_push(8);
+}
+
+
+// ============================================================================
+// UnboundedWSQ Tests
+// ============================================================================
+
+TEST_CASE("UnboundedWSQ.Resize") {
+    tf::UnboundedWSQ<void*> queue(1);
+    REQUIRE(queue.capacity() == 2);
+
+    std::vector<void*> data(2048);
+
+    auto first = data.data();
+    queue.bulk_push(first, 1);
+    REQUIRE(queue.size()     == 1);
+    REQUIRE(queue.capacity() == 2);
+
+    first = data.data();
+    queue.bulk_push(first, 2);
+    REQUIRE(queue.size()     == 3);
+    REQUIRE(queue.capacity() == 4);
+
+    first = data.data();
+    queue.bulk_push(first, 10);
+    REQUIRE(queue.size()     == 13);
+    REQUIRE(queue.capacity() == 16);
+
+    first = data.data();
+    queue.bulk_push(first, 1200);
+    REQUIRE(queue.size()     == 1213);
+    REQUIRE(queue.capacity() == 2048);
+
+    for(size_t i=0; i<1213; ++i) {
+        REQUIRE(queue.size() == 1213 - i);
+        queue.pop();
+    }
+    REQUIRE(queue.empty() == true);
+
+    // capacity does not shrink after drain
+    first = data.data();
+    queue.bulk_push(first, 1);
+    REQUIRE(queue.size()     == 1);
+    REQUIRE(queue.capacity() == 2048);
+
+    first = data.data();
+    queue.bulk_push(first, 2);
+    REQUIRE(queue.size()     == 3);
+    REQUIRE(queue.capacity() == 2048);
+
+    first = data.data();
+    queue.bulk_push(first, 10);
+    REQUIRE(queue.size()     == 13);
+    REQUIRE(queue.capacity() == 2048);
+
+    first = data.data();
+    queue.bulk_push(first, 1200);
+    REQUIRE(queue.size()     == 1213);
+    REQUIRE(queue.capacity() == 2048);
+}
+
+// Procedure: unbounded_wsq_owner
+void unbounded_wsq_owner() {
+
+    tf::UnboundedWSQ<void*> queue;
+    std::vector<void*> gold;
+
+    for(size_t N=1; N<=777777; N=N*2+1) {
+
+        gold.resize(N);
+        REQUIRE(queue.empty());
+
+        for(size_t i=0; i<N; ++i) {
+            gold[i] = gold.data() + i;
+            queue.push(gold[i]);
+        }
+        for(size_t i=0; i<N; ++i) {
+            auto ptr = queue.pop();
+            REQUIRE(ptr != nullptr);
+            REQUIRE(gold[N-i-1] == ptr);
+        }
+        REQUIRE(queue.pop() == nullptr);
+
+        for(size_t i=0; i<N; ++i) {
+            queue.push(gold[i]);
+        }
+        for(size_t i=0; i<N; ++i) {
+            auto ptr = queue.steal();
+            REQUIRE(ptr != nullptr);
+            REQUIRE(gold[i] == ptr);
+        }
+    }
+}
+
+TEST_CASE("UnboundedWSQ.Owner" * doctest::timeout(300)) {
+    unbounded_wsq_owner();
+}
+
+
+
+// ----------------------------------------------------------------------------
+// UnboundedWSQ ValueType test
+// ----------------------------------------------------------------------------
+
+TEST_CASE("UnboundedWSQ.ValueType") {
+
+    tf::UnboundedWSQ<void*> Q1;
+    tf::UnboundedWSQ<int>   Q2;
+
     auto empty1 = Q1.empty_value();
     auto empty2 = Q2.empty_value();
 
@@ -111,14 +476,13 @@ TEST_CASE("BoundedWSQ.ValueType") {
     REQUIRE(empty1 == nullptr);
     REQUIRE(empty2 == std::nullopt);
 
-    // push/pop/steal still work normally
     auto v = Q2.pop();
     REQUIRE(v == std::nullopt);
 
-    Q2.try_push(1);
-    Q2.try_push(2);
-    Q2.try_push(3);
-    Q2.try_push(4);
+    Q2.push(1);
+    Q2.push(2);
+    Q2.push(3);
+    Q2.push(4);
 
     REQUIRE(Q2.pop()   == 4);
     REQUIRE(Q2.pop()   == 3);
@@ -126,10 +490,10 @@ TEST_CASE("BoundedWSQ.ValueType") {
     REQUIRE(Q2.pop()   == 1);
     REQUIRE(Q2.pop()   == std::nullopt);
 
-    Q2.try_push(1);
-    Q2.try_push(2);
-    Q2.try_push(3);
-    Q2.try_push(4);
+    Q2.push(1);
+    Q2.push(2);
+    Q2.push(3);
+    Q2.push(4);
     REQUIRE(Q2.steal() == 1);
     REQUIRE(Q2.steal() == 2);
     REQUIRE(Q2.steal() == 3);
@@ -138,18 +502,18 @@ TEST_CASE("BoundedWSQ.ValueType") {
 }
 
 // ----------------------------------------------------------------------------
-// BoundedWSQ Multiple Consumers Test (original, using plain steal)
+// UnboundedWSQ Multiple Consumers Test (original, using plain steal)
 // ----------------------------------------------------------------------------
 
-void bounded_wsq_n_consumers(size_t M) {
+void unbounded_wsq_n_consumers(size_t M) {
 
-    tf::BoundedWSQ<void*> queue;
+    tf::UnboundedWSQ<void*> queue;
 
     std::vector<void*> gold;
     std::atomic<size_t> consumed;
 
-    // 1, 4, 13, 40, 121, 364, 1093, 3280, 9841, 29524, 88573
-    for(size_t N=1; N<=88573; N=N*3+1) {
+    // 1, 4, 13, 40, 121, 364, 1093, 3280, 9841, 29524, 88573, 265720
+    for(size_t N=1; N<=265720; N=N*3+1) {
 
         REQUIRE(queue.empty());
 
@@ -160,6 +524,27 @@ void bounded_wsq_n_consumers(size_t M) {
             gold[i] = gold.data() + i;
         }
 
+        // master push and pop
+        for(size_t i=0; i<N; ++i) {
+            queue.push(gold.data() + i);
+        }
+        REQUIRE(queue.size() == N);
+        for(size_t i=0; i<N; i++) {
+            REQUIRE(queue.pop() == gold[N - i - 1]);
+        }
+        REQUIRE(queue.empty() == true);
+
+        // master push and steal
+        for(size_t i=0; i<N; ++i) {
+            queue.push(gold.data() + i);
+        }
+        REQUIRE(queue.size() == N);
+        for(size_t i=0; i<N; i++) {
+            REQUIRE(queue.steal() == gold[i]);
+        }
+        REQUIRE(queue.empty() == true);
+
+        // concurrent
         std::vector<std::thread> threads;
         std::vector<std::vector<void*>> stolens(M);
 
@@ -177,7 +562,7 @@ void bounded_wsq_n_consumers(size_t M) {
         }
 
         for(size_t i=0; i<N; ++i) {
-            while(queue.try_push(gold[i]) == false);
+            queue.push(gold[i]);
         }
 
         std::vector<void*> items;
@@ -205,51 +590,51 @@ void bounded_wsq_n_consumers(size_t M) {
     }
 }
 
-TEST_CASE("BoundedWSQ.1Consumer" * doctest::timeout(300)) {
-    bounded_wsq_n_consumers(1);
+TEST_CASE("UnboundedWSQ.1Consumer" * doctest::timeout(300)) {
+    unbounded_wsq_n_consumers(1);
 }
 
-TEST_CASE("BoundedWSQ.2Consumers" * doctest::timeout(300)) {
-    bounded_wsq_n_consumers(2);
+TEST_CASE("UnboundedWSQ.2Consumers" * doctest::timeout(300)) {
+    unbounded_wsq_n_consumers(2);
 }
 
-TEST_CASE("BoundedWSQ.3Consumers" * doctest::timeout(300)) {
-    bounded_wsq_n_consumers(3);
+TEST_CASE("UnboundedWSQ.3Consumers" * doctest::timeout(300)) {
+    unbounded_wsq_n_consumers(3);
 }
 
-TEST_CASE("BoundedWSQ.4Consumers" * doctest::timeout(300)) {
-    bounded_wsq_n_consumers(4);
+TEST_CASE("UnboundedWSQ.4Consumers" * doctest::timeout(300)) {
+    unbounded_wsq_n_consumers(4);
 }
 
-TEST_CASE("BoundedWSQ.5Consumers" * doctest::timeout(300)) {
-    bounded_wsq_n_consumers(5);
+TEST_CASE("UnboundedWSQ.5Consumers" * doctest::timeout(300)) {
+    unbounded_wsq_n_consumers(5);
 }
 
-TEST_CASE("BoundedWSQ.6Consumers" * doctest::timeout(300)) {
-    bounded_wsq_n_consumers(6);
+TEST_CASE("UnboundedWSQ.6Consumers" * doctest::timeout(300)) {
+    unbounded_wsq_n_consumers(6);
 }
 
-TEST_CASE("BoundedWSQ.7Consumers" * doctest::timeout(300)) {
-    bounded_wsq_n_consumers(7);
+TEST_CASE("UnboundedWSQ.7Consumers" * doctest::timeout(300)) {
+    unbounded_wsq_n_consumers(7);
 }
 
-TEST_CASE("BoundedWSQ.8Consumers" * doctest::timeout(300)) {
-    bounded_wsq_n_consumers(8);
+TEST_CASE("UnboundedWSQ.8Consumers" * doctest::timeout(300)) {
+    unbounded_wsq_n_consumers(8);
 }
 
 // ----------------------------------------------------------------------------
-// BoundedWSQ Multiple Consumers BulkPush Test
+// UnboundedWSQ Multiple Consumers BulkPush Test
 // ----------------------------------------------------------------------------
 
-void bounded_wsq_n_consumers_bulk_push(size_t M) {
+void unbounded_wsq_n_consumers_bulk_push(size_t M) {
 
-    tf::BoundedWSQ<void*> queue;
+    tf::UnboundedWSQ<void*> queue;
 
     std::vector<void*> gold;
     std::atomic<size_t> consumed;
 
-    // 1, 4, 13, 40, 121, 364, 1093, 3280, 9841, 29524, 88573
-    for(size_t N=1; N<=88573; N=N*3+1) {
+    // 1, 4, 13, 40, 121, 364, 1093, 3280, 9841, 29524, 88573, 265720
+    for(size_t N=1; N<=265720; N=N*3+1) {
 
         REQUIRE(queue.empty());
 
@@ -260,28 +645,25 @@ void bounded_wsq_n_consumers_bulk_push(size_t M) {
             gold[i] = gold.data() + i;
         }
 
-        size_t capacity = queue.capacity();
-        const size_t num_pushable = std::min(capacity, N);
-
         // bulk push and pop
         auto first = gold.data();
-        REQUIRE(num_pushable == queue.try_bulk_push(first, N));
-        REQUIRE(queue.size() == num_pushable);
-        for(size_t i=0; i<num_pushable; i++) {
-            REQUIRE(queue.pop() == gold[num_pushable - i - 1]);
+        queue.bulk_push(first, N);
+        REQUIRE(queue.size() == N);
+        for(size_t i=0; i<N; i++) {
+            REQUIRE(queue.pop() == gold[N - i - 1]);
         }
         REQUIRE(queue.empty() == true);
 
         // bulk push and steal
         first = gold.data();
-        REQUIRE(num_pushable == queue.try_bulk_push(first, N));
-        REQUIRE(queue.size() == num_pushable);
-        for(size_t i=0; i<num_pushable; i++) {
+        queue.bulk_push(first, N);
+        REQUIRE(queue.size() == N);
+        for(size_t i=0; i<N; i++) {
             REQUIRE(queue.steal() == gold[i]);
         }
         REQUIRE(queue.empty() == true);
 
-        // concurrent bulk push + thieves
+        // concurrent
         std::vector<std::thread> threads;
         std::vector<std::vector<void*>> stolens(M);
 
@@ -299,9 +681,7 @@ void bounded_wsq_n_consumers_bulk_push(size_t M) {
         }
 
         first = gold.data();
-        for(size_t n=0; n<N;) {
-            n += queue.try_bulk_push(first, N-n);
-        }
+        queue.bulk_push(first, N);
 
         std::vector<void*> items;
         while(consumed != N) {
@@ -328,45 +708,46 @@ void bounded_wsq_n_consumers_bulk_push(size_t M) {
     }
 }
 
-TEST_CASE("BoundedWSQ.1Consumer.BulkPush" * doctest::timeout(300)) {
-    bounded_wsq_n_consumers_bulk_push(1);
+TEST_CASE("UnboundedWSQ.1Consumer.BulkPush" * doctest::timeout(300)) {
+    unbounded_wsq_n_consumers_bulk_push(1);
 }
 
-TEST_CASE("BoundedWSQ.2Consumers.BulkPush" * doctest::timeout(300)) {
-    bounded_wsq_n_consumers_bulk_push(2);
+TEST_CASE("UnboundedWSQ.2Consumers.BulkPush" * doctest::timeout(300)) {
+    unbounded_wsq_n_consumers_bulk_push(2);
 }
 
-TEST_CASE("BoundedWSQ.3Consumers.BulkPush" * doctest::timeout(300)) {
-    bounded_wsq_n_consumers_bulk_push(3);
+TEST_CASE("UnboundedWSQ.3Consumers.BulkPush" * doctest::timeout(300)) {
+    unbounded_wsq_n_consumers_bulk_push(3);
 }
 
-TEST_CASE("BoundedWSQ.4Consumers.BulkPush" * doctest::timeout(300)) {
-    bounded_wsq_n_consumers_bulk_push(4);
+TEST_CASE("UnboundedWSQ.4Consumers.BulkPush" * doctest::timeout(300)) {
+    unbounded_wsq_n_consumers_bulk_push(4);
 }
 
-TEST_CASE("BoundedWSQ.5Consumers.BulkPush" * doctest::timeout(300)) {
-    bounded_wsq_n_consumers_bulk_push(5);
+TEST_CASE("UnboundedWSQ.5Consumers.BulkPush" * doctest::timeout(300)) {
+    unbounded_wsq_n_consumers_bulk_push(5);
 }
 
-TEST_CASE("BoundedWSQ.6Consumers.BulkPush" * doctest::timeout(300)) {
-    bounded_wsq_n_consumers_bulk_push(6);
+TEST_CASE("UnboundedWSQ.6Consumers.BulkPush" * doctest::timeout(300)) {
+    unbounded_wsq_n_consumers_bulk_push(6);
 }
 
-TEST_CASE("BoundedWSQ.7Consumers.BulkPush" * doctest::timeout(300)) {
-    bounded_wsq_n_consumers_bulk_push(7);
+TEST_CASE("UnboundedWSQ.7Consumers.BulkPush" * doctest::timeout(300)) {
+    unbounded_wsq_n_consumers_bulk_push(7);
 }
 
-TEST_CASE("BoundedWSQ.8Consumers.BulkPush" * doctest::timeout(300)) {
-    bounded_wsq_n_consumers_bulk_push(8);
+TEST_CASE("UnboundedWSQ.8Consumers.BulkPush" * doctest::timeout(300)) {
+    unbounded_wsq_n_consumers_bulk_push(8);
 }
+
 
 
 // ============================================================================
-// UnboundedWSQ Tests  (steal-only: pop() has been removed)
+// OverflowWSQ Tests  (steal-only: pop() has been removed)
 // ============================================================================
 
-TEST_CASE("UnboundedWSQ.Resize") {
-    tf::UnboundedWSQ<void*> queue(1);
+TEST_CASE("OverflowWSQ.Resize") {
+    tf::OverflowWSQ<void*> queue(1);
     REQUIRE(queue.capacity() == 2);
 
     std::vector<void*> data(2048);
@@ -419,11 +800,11 @@ TEST_CASE("UnboundedWSQ.Resize") {
     REQUIRE(queue.capacity() == 2048);
 }
 
-// Procedure: unbounded_wsq_owner
+// Procedure: overflow_wsq_owner
 // steal-only: push N then verify FIFO drain via steal.
-void unbounded_wsq_owner() {
+void overflow_wsq_owner() {
 
-    tf::UnboundedWSQ<void*> queue;
+    tf::OverflowWSQ<void*> queue;
     std::vector<void*> gold;
 
     for(size_t N=1; N<=777777; N=N*2+1) {
@@ -444,20 +825,20 @@ void unbounded_wsq_owner() {
     }
 }
 
-TEST_CASE("UnboundedWSQ.Owner" * doctest::timeout(300)) {
-    unbounded_wsq_owner();
+TEST_CASE("OverflowWSQ.Owner" * doctest::timeout(300)) {
+    overflow_wsq_owner();
 }
 
 
 
 // ----------------------------------------------------------------------------
-// UnboundedWSQ ValueType test
+// OverflowWSQ ValueType test
 // ----------------------------------------------------------------------------
 
-TEST_CASE("UnboundedWSQ.ValueType") {
+TEST_CASE("OverflowWSQ.ValueType") {
 
-    tf::UnboundedWSQ<void*> Q1;
-    tf::UnboundedWSQ<int>   Q2;
+    tf::OverflowWSQ<void*> Q1;
+    tf::OverflowWSQ<int>   Q2;
 
     auto empty1 = Q1.empty_value();
     auto empty2 = Q2.empty_value();
@@ -483,12 +864,12 @@ TEST_CASE("UnboundedWSQ.ValueType") {
 }
 
 // ----------------------------------------------------------------------------
-// UnboundedWSQ Multiple Consumers Test (steal-only)
+// OverflowWSQ Multiple Consumers Test (steal-only)
 // ----------------------------------------------------------------------------
 
-void unbounded_wsq_n_consumers(size_t M) {
+void overflow_wsq_n_consumers(size_t M) {
 
-    tf::UnboundedWSQ<void*> queue;
+    tf::OverflowWSQ<void*> queue;
 
     std::vector<void*> gold;
     std::atomic<size_t> consumed;
@@ -557,45 +938,45 @@ void unbounded_wsq_n_consumers(size_t M) {
     }
 }
 
-TEST_CASE("UnboundedWSQ.1Consumer" * doctest::timeout(300)) {
-    unbounded_wsq_n_consumers(1);
+TEST_CASE("OverflowWSQ.1Consumer" * doctest::timeout(300)) {
+    overflow_wsq_n_consumers(1);
 }
 
-TEST_CASE("UnboundedWSQ.2Consumers" * doctest::timeout(300)) {
-    unbounded_wsq_n_consumers(2);
+TEST_CASE("OverflowWSQ.2Consumers" * doctest::timeout(300)) {
+    overflow_wsq_n_consumers(2);
 }
 
-TEST_CASE("UnboundedWSQ.3Consumers" * doctest::timeout(300)) {
-    unbounded_wsq_n_consumers(3);
+TEST_CASE("OverflowWSQ.3Consumers" * doctest::timeout(300)) {
+    overflow_wsq_n_consumers(3);
 }
 
-TEST_CASE("UnboundedWSQ.4Consumers" * doctest::timeout(300)) {
-    unbounded_wsq_n_consumers(4);
+TEST_CASE("OverflowWSQ.4Consumers" * doctest::timeout(300)) {
+    overflow_wsq_n_consumers(4);
 }
 
-TEST_CASE("UnboundedWSQ.5Consumers" * doctest::timeout(300)) {
-    unbounded_wsq_n_consumers(5);
+TEST_CASE("OverflowWSQ.5Consumers" * doctest::timeout(300)) {
+    overflow_wsq_n_consumers(5);
 }
 
-TEST_CASE("UnboundedWSQ.6Consumers" * doctest::timeout(300)) {
-    unbounded_wsq_n_consumers(6);
+TEST_CASE("OverflowWSQ.6Consumers" * doctest::timeout(300)) {
+    overflow_wsq_n_consumers(6);
 }
 
-TEST_CASE("UnboundedWSQ.7Consumers" * doctest::timeout(300)) {
-    unbounded_wsq_n_consumers(7);
+TEST_CASE("OverflowWSQ.7Consumers" * doctest::timeout(300)) {
+    overflow_wsq_n_consumers(7);
 }
 
-TEST_CASE("UnboundedWSQ.8Consumers" * doctest::timeout(300)) {
-    unbounded_wsq_n_consumers(8);
+TEST_CASE("OverflowWSQ.8Consumers" * doctest::timeout(300)) {
+    overflow_wsq_n_consumers(8);
 }
 
 // ----------------------------------------------------------------------------
-// UnboundedWSQ Multiple Consumers BulkPush Test (steal-only)
+// OverflowWSQ Multiple Consumers BulkPush Test (steal-only)
 // ----------------------------------------------------------------------------
 
-void unbounded_wsq_n_consumers_bulk_push(size_t M) {
+void overflow_wsq_n_consumers_bulk_push(size_t M) {
 
-    tf::UnboundedWSQ<void*> queue;
+    tf::OverflowWSQ<void*> queue;
 
     std::vector<void*> gold;
     std::atomic<size_t> consumed;
@@ -662,34 +1043,35 @@ void unbounded_wsq_n_consumers_bulk_push(size_t M) {
     }
 }
 
-TEST_CASE("UnboundedWSQ.1Consumer.BulkPush" * doctest::timeout(300)) {
-    unbounded_wsq_n_consumers_bulk_push(1);
+TEST_CASE("OverflowWSQ.1Consumer.BulkPush" * doctest::timeout(300)) {
+    overflow_wsq_n_consumers_bulk_push(1);
 }
 
-TEST_CASE("UnboundedWSQ.2Consumers.BulkPush" * doctest::timeout(300)) {
-    unbounded_wsq_n_consumers_bulk_push(2);
+TEST_CASE("OverflowWSQ.2Consumers.BulkPush" * doctest::timeout(300)) {
+    overflow_wsq_n_consumers_bulk_push(2);
 }
 
-TEST_CASE("UnboundedWSQ.3Consumers.BulkPush" * doctest::timeout(300)) {
-    unbounded_wsq_n_consumers_bulk_push(3);
+TEST_CASE("OverflowWSQ.3Consumers.BulkPush" * doctest::timeout(300)) {
+    overflow_wsq_n_consumers_bulk_push(3);
 }
 
-TEST_CASE("UnboundedWSQ.4Consumers.BulkPush" * doctest::timeout(300)) {
-    unbounded_wsq_n_consumers_bulk_push(4);
+TEST_CASE("OverflowWSQ.4Consumers.BulkPush" * doctest::timeout(300)) {
+    overflow_wsq_n_consumers_bulk_push(4);
 }
 
-TEST_CASE("UnboundedWSQ.5Consumers.BulkPush" * doctest::timeout(300)) {
-    unbounded_wsq_n_consumers_bulk_push(5);
+TEST_CASE("OverflowWSQ.5Consumers.BulkPush" * doctest::timeout(300)) {
+    overflow_wsq_n_consumers_bulk_push(5);
 }
 
-TEST_CASE("UnboundedWSQ.6Consumers.BulkPush" * doctest::timeout(300)) {
-    unbounded_wsq_n_consumers_bulk_push(6);
+TEST_CASE("OverflowWSQ.6Consumers.BulkPush" * doctest::timeout(300)) {
+    overflow_wsq_n_consumers_bulk_push(6);
 }
 
-TEST_CASE("UnboundedWSQ.7Consumers.BulkPush" * doctest::timeout(300)) {
-    unbounded_wsq_n_consumers_bulk_push(7);
+TEST_CASE("OverflowWSQ.7Consumers.BulkPush" * doctest::timeout(300)) {
+    overflow_wsq_n_consumers_bulk_push(7);
 }
 
-TEST_CASE("UnboundedWSQ.8Consumers.BulkPush" * doctest::timeout(300)) {
-    unbounded_wsq_n_consumers_bulk_push(8);
+TEST_CASE("OverflowWSQ.8Consumers.BulkPush" * doctest::timeout(300)) {
+    overflow_wsq_n_consumers_bulk_push(8);
 }
+

--- a/unittests/test_wsq.cpp
+++ b/unittests/test_wsq.cpp
@@ -1,4 +1,4 @@
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+﻿#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 
 #include <doctest.h>
 #include <taskflow/taskflow.hpp>
@@ -15,80 +15,80 @@
 template<size_t LogSize>
 void bounded_wsq_owner() {
 
-  tf::BoundedWSQ<void*, LogSize> queue;
+    tf::BoundedWSQ<void*, LogSize> queue;
 
-  constexpr size_t N = (1 << LogSize);
+    constexpr size_t N = (1 << LogSize);
 
-  std::vector<void*> data(1);  // dummy space to avoid nullptr when calling .data
+    std::vector<void*> data(1);  // dummy space to avoid nullptr when calling .data
 
-  for(size_t k=0; k<LogSize*10; k++) {
+    for(size_t k=0; k<LogSize*10; k++) {
 
-    data.clear();
+        data.clear();
 
-    REQUIRE(queue.empty() == true);
+        REQUIRE(queue.empty() == true);
 
-    for(size_t i=0; i<N; i++) {
-      auto ptr = data.data() + i;
-      REQUIRE(queue.try_push(ptr) == true);
-      data.push_back(ptr);
+        for(size_t i=0; i<N; i++) {
+            auto ptr = data.data() + i;
+            REQUIRE(queue.try_push(ptr) == true);
+            data.push_back(ptr);
+        }
+        REQUIRE(queue.try_push(nullptr) == false);
+
+        for(size_t i=0; i<N; i++) {
+            auto item = queue.pop();
+            REQUIRE(item != nullptr);
+            REQUIRE(item == data[N-i-1]);
+        }
+
+        for(size_t i=0; i<N; i++) {
+            REQUIRE(queue.pop() == nullptr);
+        }
     }
-    REQUIRE(queue.try_push(nullptr) == false);
 
-    for(size_t i=0; i<N; i++) {
-      auto item = queue.pop();
-      REQUIRE(item != nullptr);
-      REQUIRE(item == data[N-i-1]);
-    }
+    // test steal (plain, two-state)
+    size_t dummy1, dummy2;
 
-    for(size_t i=0; i<N; i++) {
-      REQUIRE(queue.pop() == nullptr);
-    }
-  }
-
-  // test steal (plain, two-state)
-  size_t dummy1, dummy2;
-
-  REQUIRE(queue.try_push(&dummy1) == true);
-  REQUIRE(queue.try_push(&dummy2) == true);
-  REQUIRE(queue.steal() == &dummy1);
-  REQUIRE(queue.steal() == &dummy2);
-  REQUIRE(queue.steal() == nullptr);
+    REQUIRE(queue.try_push(&dummy1) == true);
+    REQUIRE(queue.try_push(&dummy2) == true);
+    REQUIRE(queue.steal() == &dummy1);
+    REQUIRE(queue.steal() == &dummy2);
+    REQUIRE(queue.steal() == nullptr);
 }
 
 TEST_CASE("BoundedWSQ.Owner.LogSize=2" * doctest::timeout(300)) {
-  bounded_wsq_owner<2>();
+    bounded_wsq_owner<2>();
 }
 
 TEST_CASE("BoundedWSQ.Owner.LogSize=3" * doctest::timeout(300)) {
-  bounded_wsq_owner<3>();
+    bounded_wsq_owner<3>();
 }
 
 TEST_CASE("BoundedWSQ.Owner.LogSize=4" * doctest::timeout(300)) {
-  bounded_wsq_owner<4>();
+    bounded_wsq_owner<4>();
 }
 
 TEST_CASE("BoundedWSQ.Owner.LogSize=5" * doctest::timeout(300)) {
-  bounded_wsq_owner<5>();
+    bounded_wsq_owner<5>();
 }
 
 TEST_CASE("BoundedWSQ.Owner.LogSize=6" * doctest::timeout(300)) {
-  bounded_wsq_owner<6>();
+    bounded_wsq_owner<6>();
 }
 
 TEST_CASE("BoundedWSQ.Owner.LogSize=7" * doctest::timeout(300)) {
-  bounded_wsq_owner<7>();
+    bounded_wsq_owner<7>();
 }
 
 TEST_CASE("BoundedWSQ.Owner.LogSize=8" * doctest::timeout(300)) {
-  bounded_wsq_owner<8>();
+    bounded_wsq_owner<8>();
 }
 
 TEST_CASE("BoundedWSQ.Owner.LogSize=9" * doctest::timeout(300)) {
-  bounded_wsq_owner<9>();
+    bounded_wsq_owner<9>();
 }
 
 TEST_CASE("BoundedWSQ.Owner.LogSize=10" * doctest::timeout(300)) {
-  bounded_wsq_owner<10>();
+    bounded_wsq_owner<10>();
 }
 
 
@@ -98,43 +98,43 @@ TEST_CASE("BoundedWSQ.Owner.LogSize=10" * doctest::timeout(300)) {
 // ----------------------------------------------------------------------------
 
 TEST_CASE("BoundedWSQ.ValueType") {
-  tf::BoundedWSQ<void*> Q1;
-  tf::BoundedWSQ<int>   Q2;
+    tf::BoundedWSQ<void*> Q1;
+    tf::BoundedWSQ<int>   Q2;
 
-  // empty_value(): nullptr for pointer types, nullopt for non-pointer
-  auto empty1 = Q1.empty_value();
-  auto empty2 = Q2.empty_value();
+    // empty_value(): nullptr for pointer types, nullopt for non-pointer
+    auto empty1 = Q1.empty_value();
+    auto empty2 = Q2.empty_value();
 
-  static_assert(std::is_same_v<decltype(empty1), void*>);
-  static_assert(std::is_same_v<decltype(empty2), std::optional<int>>);
+    static_assert(std::is_same_v<decltype(empty1), void*>);
+    static_assert(std::is_same_v<decltype(empty2), std::optional<int>>);
 
-  REQUIRE(empty1 == nullptr);
-  REQUIRE(empty2 == std::nullopt);
+    REQUIRE(empty1 == nullptr);
+    REQUIRE(empty2 == std::nullopt);
 
-  // push/pop/steal still work normally
-  auto v = Q2.pop();
-  REQUIRE(v == std::nullopt);
+    // push/pop/steal still work normally
+    auto v = Q2.pop();
+    REQUIRE(v == std::nullopt);
 
-  Q2.try_push(1);
-  Q2.try_push(2);
-  Q2.try_push(3);
-  Q2.try_push(4);
+    Q2.try_push(1);
+    Q2.try_push(2);
+    Q2.try_push(3);
+    Q2.try_push(4);
 
-  REQUIRE(Q2.pop()   == 4);
-  REQUIRE(Q2.pop()   == 3);
-  REQUIRE(Q2.pop()   == 2);
-  REQUIRE(Q2.pop()   == 1);
-  REQUIRE(Q2.pop()   == std::nullopt);
+    REQUIRE(Q2.pop()   == 4);
+    REQUIRE(Q2.pop()   == 3);
+    REQUIRE(Q2.pop()   == 2);
+    REQUIRE(Q2.pop()   == 1);
+    REQUIRE(Q2.pop()   == std::nullopt);
 
-  Q2.try_push(1);
-  Q2.try_push(2);
-  Q2.try_push(3);
-  Q2.try_push(4);
-  REQUIRE(Q2.steal() == 1);
-  REQUIRE(Q2.steal() == 2);
-  REQUIRE(Q2.steal() == 3);
-  REQUIRE(Q2.steal() == 4);
-  REQUIRE(Q2.steal() == std::nullopt);
+    Q2.try_push(1);
+    Q2.try_push(2);
+    Q2.try_push(3);
+    Q2.try_push(4);
+    REQUIRE(Q2.steal() == 1);
+    REQUIRE(Q2.steal() == 2);
+    REQUIRE(Q2.steal() == 3);
+    REQUIRE(Q2.steal() == 4);
+    REQUIRE(Q2.steal() == std::nullopt);
 }
 
 // ----------------------------------------------------------------------------
@@ -143,98 +143,98 @@ TEST_CASE("BoundedWSQ.ValueType") {
 
 void bounded_wsq_n_consumers(size_t M) {
 
-  tf::BoundedWSQ<void*> queue;
+    tf::BoundedWSQ<void*> queue;
 
-  std::vector<void*> gold;
-  std::atomic<size_t> consumed;
+    std::vector<void*> gold;
+    std::atomic<size_t> consumed;
 
-  // 1, 4, 13, 40, 121, 364, 1093, 3280, 9841, 29524, 88573
-  for(size_t N=1; N<=88573; N=N*3+1) {
+    // 1, 4, 13, 40, 121, 364, 1093, 3280, 9841, 29524, 88573
+    for(size_t N=1; N<=88573; N=N*3+1) {
 
-    REQUIRE(queue.empty());
+        REQUIRE(queue.empty());
 
-    gold.resize(N);
-    consumed = 0;
+        gold.resize(N);
+        consumed = 0;
 
-    for(size_t i=0; i<N; ++i) {
-      gold[i] = gold.data() + i;
-    }
+        for(size_t i=0; i<N; ++i) {
+            gold[i] = gold.data() + i;
+        }
 
-    std::vector<std::thread> threads;
-    std::vector<std::vector<void*>> stolens(M);
+        std::vector<std::thread> threads;
+        std::vector<std::vector<void*>> stolens(M);
 
-    for(size_t i=0; i<M; ++i) {
-      threads.emplace_back([&, i](){
+        for(size_t i=0; i<M; ++i) {
+            threads.emplace_back([&, i](){
+                while(consumed != N) {
+                    auto ptr = queue.steal();
+                    if(ptr != nullptr) {
+                        stolens[i].push_back(ptr);
+                        consumed.fetch_add(1, std::memory_order_relaxed);
+                    }
+                }
+                REQUIRE(queue.steal() == nullptr);
+            });
+        }
+
+        for(size_t i=0; i<N; ++i) {
+            while(queue.try_push(gold[i]) == false);
+        }
+
+        std::vector<void*> items;
         while(consumed != N) {
-          auto ptr = queue.steal();
-          if(ptr != nullptr) {
-            stolens[i].push_back(ptr);
-            consumed.fetch_add(1, std::memory_order_relaxed);
-          }
+            auto ptr = queue.pop();
+            if(ptr != nullptr) {
+                items.push_back(ptr);
+                consumed.fetch_add(1, std::memory_order_relaxed);
+            }
         }
         REQUIRE(queue.steal() == nullptr);
-      });
+        REQUIRE(queue.pop()   == nullptr);
+        REQUIRE(queue.empty());
+
+        for(auto& thread : threads) thread.join();
+
+        for(size_t i=0; i<M; ++i) {
+            for(auto s : stolens[i]) items.push_back(s);
+        }
+
+        std::sort(items.begin(), items.end());
+        std::sort(gold.begin(),  gold.end());
+        REQUIRE(items.size() == N);
+        REQUIRE(items == gold);
     }
-
-    for(size_t i=0; i<N; ++i) {
-      while(queue.try_push(gold[i]) == false);
-    }
-
-    std::vector<void*> items;
-    while(consumed != N) {
-      auto ptr = queue.pop();
-      if(ptr != nullptr) {
-        items.push_back(ptr);
-        consumed.fetch_add(1, std::memory_order_relaxed);
-      }
-    }
-    REQUIRE(queue.steal() == nullptr);
-    REQUIRE(queue.pop()   == nullptr);
-    REQUIRE(queue.empty());
-
-    for(auto& thread : threads) thread.join();
-
-    for(size_t i=0; i<M; ++i) {
-      for(auto s : stolens[i]) items.push_back(s);
-    }
-
-    std::sort(items.begin(), items.end());
-    std::sort(gold.begin(),  gold.end());
-    REQUIRE(items.size() == N);
-    REQUIRE(items == gold);
-  }
 }
 
 TEST_CASE("BoundedWSQ.1Consumer" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers(1);
+    bounded_wsq_n_consumers(1);
 }
 
 TEST_CASE("BoundedWSQ.2Consumers" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers(2);
+    bounded_wsq_n_consumers(2);
 }
 
 TEST_CASE("BoundedWSQ.3Consumers" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers(3);
+    bounded_wsq_n_consumers(3);
 }
 
 TEST_CASE("BoundedWSQ.4Consumers" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers(4);
+    bounded_wsq_n_consumers(4);
 }
 
 TEST_CASE("BoundedWSQ.5Consumers" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers(5);
+    bounded_wsq_n_consumers(5);
 }
 
 TEST_CASE("BoundedWSQ.6Consumers" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers(6);
+    bounded_wsq_n_consumers(6);
 }
 
 TEST_CASE("BoundedWSQ.7Consumers" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers(7);
+    bounded_wsq_n_consumers(7);
 }
 
 TEST_CASE("BoundedWSQ.8Consumers" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers(8);
+    bounded_wsq_n_consumers(8);
 }
 
 // ----------------------------------------------------------------------------
@@ -243,217 +243,209 @@ TEST_CASE("BoundedWSQ.8Consumers" * doctest::timeout(300)) {
 
 void bounded_wsq_n_consumers_bulk_push(size_t M) {
 
-  tf::BoundedWSQ<void*> queue;
+    tf::BoundedWSQ<void*> queue;
 
-  std::vector<void*> gold;
-  std::atomic<size_t> consumed;
+    std::vector<void*> gold;
+    std::atomic<size_t> consumed;
 
-  // 1, 4, 13, 40, 121, 364, 1093, 3280, 9841, 29524, 88573
-  for(size_t N=1; N<=88573; N=N*3+1) {
+    // 1, 4, 13, 40, 121, 364, 1093, 3280, 9841, 29524, 88573
+    for(size_t N=1; N<=88573; N=N*3+1) {
 
-    REQUIRE(queue.empty());
+        REQUIRE(queue.empty());
 
-    gold.resize(N);
-    consumed = 0;
+        gold.resize(N);
+        consumed = 0;
 
-    for(size_t i=0; i<N; ++i) {
-      gold[i] = gold.data() + i;
-    }
+        for(size_t i=0; i<N; ++i) {
+            gold[i] = gold.data() + i;
+        }
 
-    size_t capacity = queue.capacity();
-    const size_t num_pushable = std::min(capacity, N);
+        size_t capacity = queue.capacity();
+        const size_t num_pushable = std::min(capacity, N);
 
-    // bulk push and pop
-    auto first = gold.data();
-    REQUIRE(num_pushable == queue.try_bulk_push(first, N));
-    REQUIRE(queue.size() == num_pushable);
-    for(size_t i=0; i<num_pushable; i++) {
-      REQUIRE(queue.pop() == gold[num_pushable - i - 1]);
-    }
-    REQUIRE(queue.empty() == true);
+        // bulk push and pop
+        auto first = gold.data();
+        REQUIRE(num_pushable == queue.try_bulk_push(first, N));
+        REQUIRE(queue.size() == num_pushable);
+        for(size_t i=0; i<num_pushable; i++) {
+            REQUIRE(queue.pop() == gold[num_pushable - i - 1]);
+        }
+        REQUIRE(queue.empty() == true);
 
-    // bulk push and steal
-    first = gold.data();
-    REQUIRE(num_pushable == queue.try_bulk_push(first, N));
-    REQUIRE(queue.size() == num_pushable);
-    for(size_t i=0; i<num_pushable; i++) {
-      REQUIRE(queue.steal() == gold[i]);
-    }
-    REQUIRE(queue.empty() == true);
+        // bulk push and steal
+        first = gold.data();
+        REQUIRE(num_pushable == queue.try_bulk_push(first, N));
+        REQUIRE(queue.size() == num_pushable);
+        for(size_t i=0; i<num_pushable; i++) {
+            REQUIRE(queue.steal() == gold[i]);
+        }
+        REQUIRE(queue.empty() == true);
 
-    // concurrent bulk push + thieves
-    std::vector<std::thread> threads;
-    std::vector<std::vector<void*>> stolens(M);
+        // concurrent bulk push + thieves
+        std::vector<std::thread> threads;
+        std::vector<std::vector<void*>> stolens(M);
 
-    for(size_t i=0; i<M; ++i) {
-      threads.emplace_back([&, i](){
+        for(size_t i=0; i<M; ++i) {
+            threads.emplace_back([&, i](){
+                while(consumed != N) {
+                    auto ptr = queue.steal();
+                    if(ptr != nullptr) {
+                        stolens[i].push_back(ptr);
+                        consumed.fetch_add(1, std::memory_order_relaxed);
+                    }
+                }
+                REQUIRE(queue.steal() == nullptr);
+            });
+        }
+
+        first = gold.data();
+        for(size_t n=0; n<N;) {
+            n += queue.try_bulk_push(first, N-n);
+        }
+
+        std::vector<void*> items;
         while(consumed != N) {
-          auto ptr = queue.steal();
-          if(ptr != nullptr) {
-            stolens[i].push_back(ptr);
-            consumed.fetch_add(1, std::memory_order_relaxed);
-          }
+            auto ptr = queue.pop();
+            if(ptr != nullptr) {
+                items.push_back(ptr);
+                consumed.fetch_add(1, std::memory_order_relaxed);
+            }
         }
         REQUIRE(queue.steal() == nullptr);
-      });
+        REQUIRE(queue.pop()   == nullptr);
+        REQUIRE(queue.empty());
+
+        for(auto& thread : threads) thread.join();
+
+        for(size_t i=0; i<M; ++i) {
+            for(auto s : stolens[i]) items.push_back(s);
+        }
+
+        std::sort(items.begin(), items.end());
+        std::sort(gold.begin(),  gold.end());
+        REQUIRE(items.size() == N);
+        REQUIRE(items == gold);
     }
-
-    first = gold.data();
-    for(size_t n=0; n<N;) {
-      n += queue.try_bulk_push(first, N-n);
-    }
-
-    std::vector<void*> items;
-    while(consumed != N) {
-      auto ptr = queue.pop();
-      if(ptr != nullptr) {
-        items.push_back(ptr);
-        consumed.fetch_add(1, std::memory_order_relaxed);
-      }
-    }
-    REQUIRE(queue.steal() == nullptr);
-    REQUIRE(queue.pop()   == nullptr);
-    REQUIRE(queue.empty());
-
-    for(auto& thread : threads) thread.join();
-
-    for(size_t i=0; i<M; ++i) {
-      for(auto s : stolens[i]) items.push_back(s);
-    }
-
-    std::sort(items.begin(), items.end());
-    std::sort(gold.begin(),  gold.end());
-    REQUIRE(items.size() == N);
-    REQUIRE(items == gold);
-  }
 }
 
 TEST_CASE("BoundedWSQ.1Consumer.BulkPush" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers_bulk_push(1);
+    bounded_wsq_n_consumers_bulk_push(1);
 }
 
 TEST_CASE("BoundedWSQ.2Consumers.BulkPush" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers_bulk_push(2);
+    bounded_wsq_n_consumers_bulk_push(2);
 }
 
 TEST_CASE("BoundedWSQ.3Consumers.BulkPush" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers_bulk_push(3);
+    bounded_wsq_n_consumers_bulk_push(3);
 }
 
 TEST_CASE("BoundedWSQ.4Consumers.BulkPush" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers_bulk_push(4);
+    bounded_wsq_n_consumers_bulk_push(4);
 }
 
 TEST_CASE("BoundedWSQ.5Consumers.BulkPush" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers_bulk_push(5);
+    bounded_wsq_n_consumers_bulk_push(5);
 }
 
 TEST_CASE("BoundedWSQ.6Consumers.BulkPush" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers_bulk_push(6);
+    bounded_wsq_n_consumers_bulk_push(6);
 }
 
 TEST_CASE("BoundedWSQ.7Consumers.BulkPush" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers_bulk_push(7);
+    bounded_wsq_n_consumers_bulk_push(7);
 }
 
 TEST_CASE("BoundedWSQ.8Consumers.BulkPush" * doctest::timeout(300)) {
-  bounded_wsq_n_consumers_bulk_push(8);
+    bounded_wsq_n_consumers_bulk_push(8);
 }
 
 
 // ============================================================================
-// UnboundedWSQ Tests
+// UnboundedWSQ Tests  (steal-only: pop() has been removed)
 // ============================================================================
 
 TEST_CASE("UnboundedWSQ.Resize") {
-  tf::UnboundedWSQ<void*> queue(1);
-  REQUIRE(queue.capacity() == 2);
+    tf::UnboundedWSQ<void*> queue(1);
+    REQUIRE(queue.capacity() == 2);
 
-  std::vector<void*> data(2048);
+    std::vector<void*> data(2048);
 
-  auto first = data.data();
-  queue.bulk_push(first, 1);
-  REQUIRE(queue.size()     == 1);
-  REQUIRE(queue.capacity() == 2);
+    auto first = data.data();
+    queue.bulk_push(first, 1);
+    REQUIRE(queue.size()     == 1);
+    REQUIRE(queue.capacity() == 2);
 
-  first = data.data();
-  queue.bulk_push(first, 2);
-  REQUIRE(queue.size()     == 3);
-  REQUIRE(queue.capacity() == 4);
+    first = data.data();
+    queue.bulk_push(first, 2);
+    REQUIRE(queue.size()     == 3);
+    REQUIRE(queue.capacity() == 4);
 
-  first = data.data();
-  queue.bulk_push(first, 10);
-  REQUIRE(queue.size()     == 13);
-  REQUIRE(queue.capacity() == 16);
+    first = data.data();
+    queue.bulk_push(first, 10);
+    REQUIRE(queue.size()     == 13);
+    REQUIRE(queue.capacity() == 16);
 
-  first = data.data();
-  queue.bulk_push(first, 1200);
-  REQUIRE(queue.size()     == 1213);
-  REQUIRE(queue.capacity() == 2048);
+    first = data.data();
+    queue.bulk_push(first, 1200);
+    REQUIRE(queue.size()     == 1213);
+    REQUIRE(queue.capacity() == 2048);
 
-  for(size_t i=0; i<1213; ++i) {
-    REQUIRE(queue.size() == 1213 - i);
-    queue.pop();
-  }
-  REQUIRE(queue.empty() == true);
+    for(size_t i=0; i<1213; ++i) {
+        REQUIRE(queue.size() == 1213 - i);
+        queue.steal();
+    }
+    REQUIRE(queue.empty() == true);
 
-  // capacity does not shrink after drain
-  first = data.data();
-  queue.bulk_push(first, 1);
-  REQUIRE(queue.size()     == 1);
-  REQUIRE(queue.capacity() == 2048);
+    // capacity does not shrink after drain
+    first = data.data();
+    queue.bulk_push(first, 1);
+    REQUIRE(queue.size()     == 1);
+    REQUIRE(queue.capacity() == 2048);
 
-  first = data.data();
-  queue.bulk_push(first, 2);
-  REQUIRE(queue.size()     == 3);
-  REQUIRE(queue.capacity() == 2048);
+    first = data.data();
+    queue.bulk_push(first, 2);
+    REQUIRE(queue.size()     == 3);
+    REQUIRE(queue.capacity() == 2048);
 
-  first = data.data();
-  queue.bulk_push(first, 10);
-  REQUIRE(queue.size()     == 13);
-  REQUIRE(queue.capacity() == 2048);
+    first = data.data();
+    queue.bulk_push(first, 10);
+    REQUIRE(queue.size()     == 13);
+    REQUIRE(queue.capacity() == 2048);
 
-  first = data.data();
-  queue.bulk_push(first, 1200);
-  REQUIRE(queue.size()     == 1213);
-  REQUIRE(queue.capacity() == 2048);
+    first = data.data();
+    queue.bulk_push(first, 1200);
+    REQUIRE(queue.size()     == 1213);
+    REQUIRE(queue.capacity() == 2048);
 }
 
 // Procedure: unbounded_wsq_owner
+// steal-only: push N then verify FIFO drain via steal.
 void unbounded_wsq_owner() {
 
-  tf::UnboundedWSQ<void*> queue;
-  std::vector<void*> gold;
+    tf::UnboundedWSQ<void*> queue;
+    std::vector<void*> gold;
 
-  for(size_t N=1; N<=777777; N=N*2+1) {
+    for(size_t N=1; N<=777777; N=N*2+1) {
 
-    gold.resize(N);
-    REQUIRE(queue.empty());
+        gold.resize(N);
+        REQUIRE(queue.empty());
 
-    for(size_t i=0; i<N; ++i) {
-      gold[i] = gold.data() + i;
-      queue.push(gold[i]);
+        for(size_t i=0; i<N; ++i) {
+            gold[i] = gold.data() + i;
+            queue.push(gold[i]);
+        }
+        for(size_t i=0; i<N; ++i) {
+            auto ptr = queue.steal();
+            REQUIRE(ptr != nullptr);
+            REQUIRE(gold[i] == ptr);
+        }
+        REQUIRE(queue.steal() == nullptr);
     }
-    for(size_t i=0; i<N; ++i) {
-      auto ptr = queue.pop();
-      REQUIRE(ptr != nullptr);
-      REQUIRE(gold[N-i-1] == ptr);
-    }
-    REQUIRE(queue.pop() == nullptr);
-
-    for(size_t i=0; i<N; ++i) {
-      queue.push(gold[i]);
-    }
-    for(size_t i=0; i<N; ++i) {
-      auto ptr = queue.steal();
-      REQUIRE(ptr != nullptr);
-      REQUIRE(gold[i] == ptr);
-    }
-  }
 }
 
 TEST_CASE("UnboundedWSQ.Owner" * doctest::timeout(300)) {
-  unbounded_wsq_owner();
+    unbounded_wsq_owner();
 }
 
 
@@ -464,278 +456,240 @@ TEST_CASE("UnboundedWSQ.Owner" * doctest::timeout(300)) {
 
 TEST_CASE("UnboundedWSQ.ValueType") {
 
-  tf::UnboundedWSQ<void*> Q1;
-  tf::UnboundedWSQ<int>   Q2;
+    tf::UnboundedWSQ<void*> Q1;
+    tf::UnboundedWSQ<int>   Q2;
 
-  auto empty1 = Q1.empty_value();
-  auto empty2 = Q2.empty_value();
+    auto empty1 = Q1.empty_value();
+    auto empty2 = Q2.empty_value();
 
-  static_assert(std::is_same_v<decltype(empty1), void*>);
-  static_assert(std::is_same_v<decltype(empty2), std::optional<int>>);
+    static_assert(std::is_same_v<decltype(empty1), void*>);
+    static_assert(std::is_same_v<decltype(empty2), std::optional<int>>);
 
-  REQUIRE(empty1 == nullptr);
-  REQUIRE(empty2 == std::nullopt);
+    REQUIRE(empty1 == nullptr);
+    REQUIRE(empty2 == std::nullopt);
 
-  auto v = Q2.pop();
-  REQUIRE(v == std::nullopt);
+    auto v = Q2.steal();
+    REQUIRE(v == std::nullopt);
 
-  Q2.push(1);
-  Q2.push(2);
-  Q2.push(3);
-  Q2.push(4);
-
-  REQUIRE(Q2.pop()   == 4);
-  REQUIRE(Q2.pop()   == 3);
-  REQUIRE(Q2.pop()   == 2);
-  REQUIRE(Q2.pop()   == 1);
-  REQUIRE(Q2.pop()   == std::nullopt);
-
-  Q2.push(1);
-  Q2.push(2);
-  Q2.push(3);
-  Q2.push(4);
-  REQUIRE(Q2.steal() == 1);
-  REQUIRE(Q2.steal() == 2);
-  REQUIRE(Q2.steal() == 3);
-  REQUIRE(Q2.steal() == 4);
-  REQUIRE(Q2.steal() == std::nullopt);
+    Q2.push(1);
+    Q2.push(2);
+    Q2.push(3);
+    Q2.push(4);
+    REQUIRE(Q2.steal() == 1);
+    REQUIRE(Q2.steal() == 2);
+    REQUIRE(Q2.steal() == 3);
+    REQUIRE(Q2.steal() == 4);
+    REQUIRE(Q2.steal() == std::nullopt);
 }
 
 // ----------------------------------------------------------------------------
-// UnboundedWSQ Multiple Consumers Test (original, using plain steal)
+// UnboundedWSQ Multiple Consumers Test (steal-only)
 // ----------------------------------------------------------------------------
 
 void unbounded_wsq_n_consumers(size_t M) {
 
-  tf::UnboundedWSQ<void*> queue;
+    tf::UnboundedWSQ<void*> queue;
 
-  std::vector<void*> gold;
-  std::atomic<size_t> consumed;
+    std::vector<void*> gold;
+    std::atomic<size_t> consumed;
 
-  // 1, 4, 13, 40, 121, 364, 1093, 3280, 9841, 29524, 88573, 265720
-  for(size_t N=1; N<=265720; N=N*3+1) {
+    // 1, 4, 13, 40, 121, 364, 1093, 3280, 9841, 29524, 88573, 265720
+    for(size_t N=1; N<=265720; N=N*3+1) {
 
-    REQUIRE(queue.empty());
+        REQUIRE(queue.empty());
 
-    gold.resize(N);
-    consumed = 0;
+        gold.resize(N);
+        consumed = 0;
 
-    for(size_t i=0; i<N; ++i) {
-      gold[i] = gold.data() + i;
-    }
+        for(size_t i=0; i<N; ++i) {
+            gold[i] = gold.data() + i;
+        }
 
-    // master push and pop
-    for(size_t i=0; i<N; ++i) {
-      queue.push(gold.data() + i);
-    }
-    REQUIRE(queue.size() == N);
-    for(size_t i=0; i<N; i++) {
-      REQUIRE(queue.pop() == gold[N - i - 1]);
-    }
-    REQUIRE(queue.empty() == true);
+        // master push and steal (single-thread FIFO check)
+        for(size_t i=0; i<N; ++i) {
+            queue.push(gold.data() + i);
+        }
+        REQUIRE(queue.size() == N);
+        for(size_t i=0; i<N; i++) {
+            REQUIRE(queue.steal() == gold[i]);
+        }
+        REQUIRE(queue.empty() == true);
 
-    // master push and steal
-    for(size_t i=0; i<N; ++i) {
-      queue.push(gold.data() + i);
-    }
-    REQUIRE(queue.size() == N);
-    for(size_t i=0; i<N; i++) {
-      REQUIRE(queue.steal() == gold[i]);
-    }
-    REQUIRE(queue.empty() == true);
+        // concurrent: owner only pushes, all consumption done by thieves
+        std::vector<std::thread> threads;
+        std::vector<std::vector<void*>> stolens(M);
 
-    // concurrent
-    std::vector<std::thread> threads;
-    std::vector<std::vector<void*>> stolens(M);
+        for(size_t i=0; i<M; ++i) {
+            threads.emplace_back([&, i](){
+                while(consumed != N) {
+                    auto ptr = queue.steal();
+                    if(ptr != nullptr) {
+                        stolens[i].push_back(ptr);
+                        consumed.fetch_add(1, std::memory_order_relaxed);
+                    }
+                }
+                REQUIRE(queue.steal() == nullptr);
+            });
+        }
 
-    for(size_t i=0; i<M; ++i) {
-      threads.emplace_back([&, i](){
+        for(size_t i=0; i<N; ++i) {
+            queue.push(gold[i]);
+        }
+
+        // owner waits for thieves to drain (steal-only: owner cannot pop)
         while(consumed != N) {
-          auto ptr = queue.steal();
-          if(ptr != nullptr) {
-            stolens[i].push_back(ptr);
-            consumed.fetch_add(1, std::memory_order_relaxed);
-          }
+            std::this_thread::yield();
         }
         REQUIRE(queue.steal() == nullptr);
-      });
+        REQUIRE(queue.empty());
+
+        for(auto& thread : threads) thread.join();
+
+        std::vector<void*> items;
+        for(size_t i=0; i<M; ++i) {
+            for(auto s : stolens[i]) items.push_back(s);
+        }
+
+        std::sort(items.begin(), items.end());
+        std::sort(gold.begin(),  gold.end());
+        REQUIRE(items.size() == N);
+        REQUIRE(items == gold);
     }
-
-    for(size_t i=0; i<N; ++i) {
-      queue.push(gold[i]);
-    }
-
-    std::vector<void*> items;
-    while(consumed != N) {
-      auto ptr = queue.pop();
-      if(ptr != nullptr) {
-        items.push_back(ptr);
-        consumed.fetch_add(1, std::memory_order_relaxed);
-      }
-    }
-    REQUIRE(queue.steal() == nullptr);
-    REQUIRE(queue.pop()   == nullptr);
-    REQUIRE(queue.empty());
-
-    for(auto& thread : threads) thread.join();
-
-    for(size_t i=0; i<M; ++i) {
-      for(auto s : stolens[i]) items.push_back(s);
-    }
-
-    std::sort(items.begin(), items.end());
-    std::sort(gold.begin(),  gold.end());
-    REQUIRE(items.size() == N);
-    REQUIRE(items == gold);
-  }
 }
 
 TEST_CASE("UnboundedWSQ.1Consumer" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers(1);
+    unbounded_wsq_n_consumers(1);
 }
 
 TEST_CASE("UnboundedWSQ.2Consumers" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers(2);
+    unbounded_wsq_n_consumers(2);
 }
 
 TEST_CASE("UnboundedWSQ.3Consumers" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers(3);
+    unbounded_wsq_n_consumers(3);
 }
 
 TEST_CASE("UnboundedWSQ.4Consumers" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers(4);
+    unbounded_wsq_n_consumers(4);
 }
 
 TEST_CASE("UnboundedWSQ.5Consumers" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers(5);
+    unbounded_wsq_n_consumers(5);
 }
 
 TEST_CASE("UnboundedWSQ.6Consumers" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers(6);
+    unbounded_wsq_n_consumers(6);
 }
 
 TEST_CASE("UnboundedWSQ.7Consumers" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers(7);
+    unbounded_wsq_n_consumers(7);
 }
 
 TEST_CASE("UnboundedWSQ.8Consumers" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers(8);
+    unbounded_wsq_n_consumers(8);
 }
 
 // ----------------------------------------------------------------------------
-// UnboundedWSQ Multiple Consumers BulkPush Test
+// UnboundedWSQ Multiple Consumers BulkPush Test (steal-only)
 // ----------------------------------------------------------------------------
 
 void unbounded_wsq_n_consumers_bulk_push(size_t M) {
 
-  tf::UnboundedWSQ<void*> queue;
+    tf::UnboundedWSQ<void*> queue;
 
-  std::vector<void*> gold;
-  std::atomic<size_t> consumed;
+    std::vector<void*> gold;
+    std::atomic<size_t> consumed;
 
-  // 1, 4, 13, 40, 121, 364, 1093, 3280, 9841, 29524, 88573, 265720
-  for(size_t N=1; N<=265720; N=N*3+1) {
+    // 1, 4, 13, 40, 121, 364, 1093, 3280, 9841, 29524, 88573, 265720
+    for(size_t N=1; N<=265720; N=N*3+1) {
 
-    REQUIRE(queue.empty());
+        REQUIRE(queue.empty());
 
-    gold.resize(N);
-    consumed = 0;
+        gold.resize(N);
+        consumed = 0;
 
-    for(size_t i=0; i<N; ++i) {
-      gold[i] = gold.data() + i;
-    }
+        for(size_t i=0; i<N; ++i) {
+            gold[i] = gold.data() + i;
+        }
 
-    // bulk push and pop
-    auto first = gold.data();
-    queue.bulk_push(first, N);
-    REQUIRE(queue.size() == N);
-    for(size_t i=0; i<N; i++) {
-      REQUIRE(queue.pop() == gold[N - i - 1]);
-    }
-    REQUIRE(queue.empty() == true);
+        // bulk push and steal (single-thread FIFO check)
+        auto first = gold.data();
+        queue.bulk_push(first, N);
+        REQUIRE(queue.size() == N);
+        for(size_t i=0; i<N; i++) {
+            REQUIRE(queue.steal() == gold[i]);
+        }
+        REQUIRE(queue.empty() == true);
 
-    // bulk push and steal
-    first = gold.data();
-    queue.bulk_push(first, N);
-    REQUIRE(queue.size() == N);
-    for(size_t i=0; i<N; i++) {
-      REQUIRE(queue.steal() == gold[i]);
-    }
-    REQUIRE(queue.empty() == true);
+        // concurrent: owner only bulk-pushes, all consumption done by thieves
+        std::vector<std::thread> threads;
+        std::vector<std::vector<void*>> stolens(M);
 
-    // concurrent
-    std::vector<std::thread> threads;
-    std::vector<std::vector<void*>> stolens(M);
+        for(size_t i=0; i<M; ++i) {
+            threads.emplace_back([&, i](){
+                while(consumed != N) {
+                    auto ptr = queue.steal();
+                    if(ptr != nullptr) {
+                        stolens[i].push_back(ptr);
+                        consumed.fetch_add(1, std::memory_order_relaxed);
+                    }
+                }
+                REQUIRE(queue.steal() == nullptr);
+            });
+        }
 
-    for(size_t i=0; i<M; ++i) {
-      threads.emplace_back([&, i](){
+        first = gold.data();
+        queue.bulk_push(first, N);
+
+        // owner waits for thieves to drain (steal-only: owner cannot pop)
         while(consumed != N) {
-          auto ptr = queue.steal();
-          if(ptr != nullptr) {
-            stolens[i].push_back(ptr);
-            consumed.fetch_add(1, std::memory_order_relaxed);
-          }
+            std::this_thread::yield();
         }
         REQUIRE(queue.steal() == nullptr);
-      });
+        REQUIRE(queue.empty());
+
+        for(auto& thread : threads) thread.join();
+
+        std::vector<void*> items;
+        for(size_t i=0; i<M; ++i) {
+            for(auto s : stolens[i]) items.push_back(s);
+        }
+
+        std::sort(items.begin(), items.end());
+        std::sort(gold.begin(),  gold.end());
+        REQUIRE(items.size() == N);
+        REQUIRE(items == gold);
     }
-
-    first = gold.data();
-    queue.bulk_push(first, N);
-
-    std::vector<void*> items;
-    while(consumed != N) {
-      auto ptr = queue.pop();
-      if(ptr != nullptr) {
-        items.push_back(ptr);
-        consumed.fetch_add(1, std::memory_order_relaxed);
-      }
-    }
-    REQUIRE(queue.steal() == nullptr);
-    REQUIRE(queue.pop()   == nullptr);
-    REQUIRE(queue.empty());
-
-    for(auto& thread : threads) thread.join();
-
-    for(size_t i=0; i<M; ++i) {
-      for(auto s : stolens[i]) items.push_back(s);
-    }
-
-    std::sort(items.begin(), items.end());
-    std::sort(gold.begin(),  gold.end());
-    REQUIRE(items.size() == N);
-    REQUIRE(items == gold);
-  }
 }
 
 TEST_CASE("UnboundedWSQ.1Consumer.BulkPush" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers_bulk_push(1);
+    unbounded_wsq_n_consumers_bulk_push(1);
 }
 
 TEST_CASE("UnboundedWSQ.2Consumers.BulkPush" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers_bulk_push(2);
+    unbounded_wsq_n_consumers_bulk_push(2);
 }
 
 TEST_CASE("UnboundedWSQ.3Consumers.BulkPush" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers_bulk_push(3);
+    unbounded_wsq_n_consumers_bulk_push(3);
 }
 
 TEST_CASE("UnboundedWSQ.4Consumers.BulkPush" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers_bulk_push(4);
+    unbounded_wsq_n_consumers_bulk_push(4);
 }
 
 TEST_CASE("UnboundedWSQ.5Consumers.BulkPush" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers_bulk_push(5);
+    unbounded_wsq_n_consumers_bulk_push(5);
 }
 
 TEST_CASE("UnboundedWSQ.6Consumers.BulkPush" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers_bulk_push(6);
+    unbounded_wsq_n_consumers_bulk_push(6);
 }
 
 TEST_CASE("UnboundedWSQ.7Consumers.BulkPush" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers_bulk_push(7);
+    unbounded_wsq_n_consumers_bulk_push(7);
 }
 
 TEST_CASE("UnboundedWSQ.8Consumers.BulkPush" * doctest::timeout(300)) {
-  unbounded_wsq_n_consumers_bulk_push(8);
+    unbounded_wsq_n_consumers_bulk_push(8);
 }


### PR DESCRIPTION
           downgrade BoundedWSQ::steal() top load and pop() CAS to relaxed/acq_rel

UnboundedWSQ is used only as the executor's overflow region: the owner only pushes and thieves only steal — the owner never pops. With pop() gone as dead code, the cross-variable Dekker mutual-exclusion structure between top and bottom disappears, and that structure was the sole reason steal() needed a seq_cst fence and a seq_cst CAS. The downgrades follow from this:

UnboundedWSQ::steal()
  - Remove the seq_cst fence: it existed only to pair with pop()'s fence in the single total order S and arbitrate the "last element" race. With no pop(), the fence has nothing to pair with.
  - CAS success order seq_cst -> acq_rel: the only remaining contention is thief-vs-thief on the single variable top. CAS RMW atomicity guarantees exactly one thief wins, and release/acquire is sufficient to chain top's modification order; no cross-variable total order is required.
  - _top.load acquire -> relaxed: top increases monotonically, so relaxed can at worst read a smaller, stale value, making the t<b check conservative (one missed steal, never out of bounds); the CAS then re-validates against the latest top and returns empty on failure. Slot-data visibility is carried by _bottom.load(acquire) paired with push()'s release, independent of how top is read.

BoundedWSQ::steal()
  - Only _top.load acquire -> relaxed. BoundedWSQ still has pop(), so the Dekker structure remains and both the seq_cst fence and the seq_cst CAS are kept unchanged. Relaxing the top load is safe: the seq_cst fence immediately following it is a full barrier that already prevents the top load from being reordered with the subsequent bottom load and slot load — the LoadLoad reordering that acquire was meant to block is already covered by the fence. Slot visibility likewise depends on bottom's acquire chain, not on how top is read.

BoundedWSQ::pop()
  - CAS success order seq_cst -> acq_rel. The seq_cst fence in pop() is retained, and so is steal()'s seq_cst fence and steal()'s seq_cst CAS. The argument that pop()'s CAS need not enter S: * The Dekker / SB exclusion that prevents fast-path double-take is carried entirely by the two seq_cst fences plus steal()'s seq_cst CAS anchor. pop()'s own side is cleanly SB-shaped (store bottom; seq_cst fence; load top), so its fence does the SB duty on its own — pop()'s CAS is not the anchor for either fence. * pop()'s CAS executes only on the t==b (last-element) path, i.e. never on the fast path. That path is single-variable contention: owner-CAS vs thief-CAS both move top from t to t+1, and RMW atomicity guarantees exactly one winner regardless of memory order. acq_rel provides the acquire needed to observe the loser/winner state and the release to publish the claim; entry into the global total order S is not required. Net effect: pop() keeps its seq_cst fence (load-bearing) but drops one seq_cst RMW on the cold last-element path.

Tests (wsq_test.cpp)
  - UnboundedWSQ tests converted to steal-only; all UnboundedWSQ::pop() calls removed. BoundedWSQ tests are untouched (BoundedWSQ still has pop()).
  - UnboundedWSQ.Resize: drain loop pop() -> steal().
  - UnboundedWSQ.Owner / ValueType: dropped the LIFO pop() verification; the pre-existing steal() FIFO check now covers the single-thread path. Removed the now-duplicated second push round.
  - UnboundedWSQ.*Consumers / *.BulkPush: dropped the "master/bulk push and pop" LIFO blocks; in the concurrent phase the owner only pushes and waits (while(consumed != N) yield()) for thieves to drain, since a steal-only owner cannot pop. `items` is now collected solely from `stolens`, and the trailing pop()==nullptr assertion is removed (steal()==nullptr kept).