### PR TITLE
No longer test for C++11.

### DIFF
--- a/taskflow/algorithm/sort.hpp
+++ b/taskflow/algorithm/sort.hpp
@@ -34,7 +34,9 @@ constexpr size_t parallel_sort_cutoff() {
 
 template<typename T, size_t cacheline_size=64>
 inline T* align_cacheline(T* p) {
-#if defined(UINTPTR_MAX) && __cplusplus >= 201103L
+  // std::uintptr_t is a type the standard defines as optional. Use it
+  // when possible.
+#if defined(UINTPTR_MAX)
   std::uintptr_t ip = reinterpret_cast<std::uintptr_t>(p);
 #else
   std::size_t ip = reinterpret_cast<std::size_t>(p);


### PR DESCRIPTION
In looking at https://github.com/dealii/dealii/issues/19188, I found a place where the current code base still checks whether the C++ standard is at least C++11. That's no longer necessary because Taskflow requires C++20 anyway.

I also looked at the other part of the `#if` here, testing for whether `defined(UINTPTR_MAX)` exists. From C++11 to C++26, the standard defines `std::uintptr_t` as an optional type. So it's not guaranteed that it always exists, and using `defined(UINTPTR_MAX)` is still necessary.