### PR TITLE
cudaGraphBase: constrain the variadic ctor on Creator being invocable

### DIFF
--- a/taskflow/cuda/cuda_graph.hpp
+++ b/taskflow/cuda/cuda_graph.hpp
@@ -547,10 +547,11 @@ class cudaGraphBase : public std::unique_ptr<std::remove_pointer_t<cudaGraph_t>,
   @param args arguments to pass to the executable CUDA graph creator
   */
   template <typename... ArgsT>
+  requires std::invocable<Creator, ArgsT...>
   explicit cudaGraphBase(ArgsT&& ... args) : base_type(
     Creator{}(std::forward<ArgsT>(args)...), Deleter()
   ) {
-  }  
+  }
   
   /**
   @brief constructs a `cudaGraph` from the given rhs using move semantics


### PR DESCRIPTION
Fixes #753. `cudaGraphBase(ArgsT&&...)` forwards straight to `Creator{}(args...)` with no constraint, so anything that probes it via `std::constructible_from`/`if constexpr` gets a hard error from inside the constructor body instead of SFINAE'ing away cleanly. Added `requires std::invocable<Creator, ArgsT...>` — matches the fix suggested in the issue, `<concepts>` is already available transitively through traits.hpp so nothing new to include.

I don't have a CUDA toolchain here to compile-verify this against the reporter's exact `if constexpr(std::constructible_from<...>)` repro — flagging that so it gets a real build check in CI/review rather than assuming it's clean.